### PR TITLE
fix(theme): residual green rgba() in dark-mode active states + selections

### DIFF
--- a/help/help.css
+++ b/help/help.css
@@ -99,7 +99,7 @@ body {
 }
 
 [data-theme="dark"] ::selection {
-  background: rgba(24,226,153,0.25);
+  background: rgba(232,121,29,0.25);
   color: var(--help-accent);
 }
 
@@ -210,7 +210,7 @@ body {
 .help-search:focus {
   border-color: var(--help-accent);
   width: 280px;
-  box-shadow: 0 0 0 3px rgba(24,226,153,0.15);
+  box-shadow: 0 0 0 3px rgba(232,121,29,0.15);
 }
 
 .help-search:focus-visible {
@@ -277,7 +277,7 @@ body {
 }
 
 [data-theme="dark"] .help-search-result-snippet mark {
-  background: rgba(24,226,153,0.2);
+  background: rgba(232,121,29,0.2);
   color: var(--help-accent);
 }
 
@@ -367,7 +367,7 @@ body {
 
 [data-theme="dark"] .help-nav-item.active {
   color: var(--help-accent);
-  background: rgba(24,226,153,0.12);
+  background: rgba(232,121,29,0.12);
 }
 
 .help-nav-group-toggle { font-weight: 600; }
@@ -458,7 +458,7 @@ body {
 
 [data-theme="dark"] .help-toc-bar a.active {
   color: var(--help-accent);
-  background: rgba(24,226,153,0.12);
+  background: rgba(232,121,29,0.12);
 }
 
 .help-toc-bar .toc-dot {


### PR DESCRIPTION
Replace 5 hard-coded `rgba(24,226,153,...)` (green) with `rgba(232,121,29,...)` (orange) in help.css. Surfaced via user screenshot of the live demo where the active sidebar pill and TOC pill remained green-tinted.

Closes #29