### PR TITLE
fix(theme): propagate custom accent through all shades and tints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.2] - 2026-04-20
+
+### Fixed
+- Custom `accent` in `chapters.json` now propagates consistently across all UI states (#33):
+  - Five hardcoded `rgba(232,121,29,...)` sites (selection, search-glow, sidebar-active, TOC-active, code-highlight) replaced with `color-mix(in srgb, var(--help-accent) XX%, transparent)` so tints track the override
+  - `--help-accent-deep` and `--help-accent-light` now derived from `var(--help-accent)` via `color-mix()` instead of hardcoded orange tones — fixes light-mode text reverting to default orange when a custom accent is set
+
 ## [2.2.0] - 2026-04-19
 
 ### Added
@@ -125,7 +132,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Light mode code blocks and prev/next navigation bug
 - Dark mode: neutral gray/black instead of blue-tinted Catppuccin
 
-[Unreleased]: https://github.com/leminkozey/help-book/compare/v2.1.0...HEAD
+[Unreleased]: https://github.com/leminkozey/help-book/compare/v2.2.2...HEAD
+[2.2.2]: https://github.com/leminkozey/help-book/compare/v2.2.0...v2.2.2
+[2.2.0]: https://github.com/leminkozey/help-book/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/leminkozey/help-book/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/leminkozey/help-book/compare/v1.1.0...v2.0.0
 [1.1.0]: https://github.com/leminkozey/help-book/compare/v1.0.0...v1.1.0

--- a/help/chapters.json
+++ b/help/chapters.json
@@ -1,6 +1,6 @@
 {
   "title": "Help Book Demo",
-  "version": "v2.2.1",
+  "version": "v2.2.2",
   "accent": "#e8791d",
   "chapters": [
     {

--- a/help/help.css
+++ b/help/help.css
@@ -1,7 +1,7 @@
 :root {
   --help-accent: #e8791d;
-  --help-accent-deep: #c2620f;
-  --help-accent-light: #fde2cc;
+  --help-accent-deep: color-mix(in srgb, var(--help-accent) 80%, #000);
+  --help-accent-light: color-mix(in srgb, var(--help-accent) 22%, #fff);
 
   --help-bg: #f5f5f7;
   --help-bg-secondary: #eeeef0;
@@ -99,7 +99,7 @@ body {
 }
 
 [data-theme="dark"] ::selection {
-  background: rgba(232,121,29,0.25);
+  background: color-mix(in srgb, var(--help-accent) 25%, transparent);
   color: var(--help-accent);
 }
 
@@ -220,7 +220,7 @@ body {
 .help-search:focus {
   border-color: var(--help-accent);
   width: 280px;
-  box-shadow: 0 0 0 3px rgba(232,121,29,0.15);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--help-accent) 15%, transparent);
 }
 
 .help-search:focus-visible {
@@ -287,7 +287,7 @@ body {
 }
 
 [data-theme="dark"] .help-search-result-snippet mark {
-  background: rgba(232,121,29,0.2);
+  background: color-mix(in srgb, var(--help-accent) 20%, transparent);
   color: var(--help-accent);
 }
 
@@ -377,7 +377,7 @@ body {
 
 [data-theme="dark"] .help-nav-item.active {
   color: var(--help-accent);
-  background: rgba(232,121,29,0.12);
+  background: color-mix(in srgb, var(--help-accent) 12%, transparent);
 }
 
 .help-nav-group-toggle { font-weight: 600; }
@@ -468,7 +468,7 @@ body {
 
 [data-theme="dark"] .help-toc-bar a.active {
   color: var(--help-accent);
-  background: rgba(232,121,29,0.12);
+  background: color-mix(in srgb, var(--help-accent) 12%, transparent);
 }
 
 .help-toc-bar .toc-dot {


### PR DESCRIPTION
Closes #33

## Summary
- Derive `--help-accent-deep` / `--help-accent-light` from `var(--help-accent)` via `color-mix()` so a custom accent in `chapters.json` flows into every light-mode text/link and pastel background
- Replace the five hardcoded `rgba(232,121,29,...)` sites (selection, search-glow, sidebar-active, TOC-active, code-highlight) with `color-mix(in srgb, var(--help-accent) XX%, transparent)` — same class of bug that was fixed for the green values in v2.1.0
- Bump `chapters.json` version to v2.2.2 and add a 2.2.2 CHANGELOG entry

## Before
Setting a custom accent only recolored logo + body text. Sidebar-active, TOC-active, search-glow, code-highlight and selection stayed orange; toggling light mode reverted body text to the default orange shade.

## After
Accent propagates consistently through both themes. Verified locally with a blue (`#2563eb`) override — all tinted surfaces track the accent in both light and dark mode.

## Test plan
- [x] `help/chapters.json` accent override → custom color applies to sidebar-active, TOC-active, search-focus glow, code highlight, selection, link hover
- [x] Light + dark theme toggle keeps the accent consistent
- [x] Default (`#e8791d` orange) still looks identical to v2.2.1