### PR TITLE
v2.3.0: impeccable audit pass — P0 through P3 fixes

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -1,0 +1,23 @@
+## Design Context
+
+### Users
+Developer, die ein drop-in Dokumentations-System in ihre Web-Projekte einbauen wollen, und deren Endnutzer (die Dokumentation lesen, suchen, Code-Snippets kopieren). Primärer Kontext: Developer evaluieren/integrieren help-book, End-User lesen Docs im Browser — oft nachts/abends, gelegentlich mobil. Technisches Publikum, das Keyboard-Shortcuts nutzt (Cmd+K Search).
+
+### Brand Personality
+- **Drei Worte:** handwerklich, opinionated, warm-technical
+- **Voice:** Selbstbewusst aber nie laut. Minimalistisch mit Persönlichkeit. Warm orange (`#e8791d`) als Fox-Brand von Lemin Kozey — steht gegen den Standard-Mintlify-Grün-Einheitsbrei.
+- **Emotional goal:** Vertrauen in die Doku + Freude beim Durchstöbern, nicht "Corporate Boring".
+
+### Aesthetic Direction
+- **Visuell:** Mintlify-inspiriertes Layout + macOS-Settings floating sidebar + 16px card-radius + 5%-opacity borders + großzügiges Whitespace statt Divider-Lines
+- **Theme:** Beide — Light als Default, Dark mit System-Pref. Kein Dark-Mode-Default "weil cool".
+- **Typografie:** Inter (Body) + Geist Mono (Code/Labels) — bewusste Pairing, kein Mono-only "developer vibes"
+- **Farben:** Tinted neutrals in Richtung warm orange, accents sparsam einsetzen
+- **Anti-References:** Mintlify-Green-Default, GitBook-Sterilität, ReadTheDocs-Zeiten, alles mit "hero metrics" Layout
+
+### Design Principles
+1. **Content first** — die Doku ist der Star, UI verschwindet hinter dem Text
+2. **Keine Border-Stripes, keine Card-in-Card** — help-book hat aktuell einen `border-left: 3px solid var(--help-accent)` auf blockquotes (DESIGN.md-Anti-Pattern — muss weg)
+3. **Accent ist rar** — warm orange nur für echte State-Changes (active nav, active TOC, focus, selection, link hover)
+4. **Keyboard-first** — Cmd+K Search, Tab-Nav, Skip-Link, Focus-Indicators überall
+5. **No framework lock-in** — Vanilla HTML/CSS/JS, keine Build-Schritte, muss in jedem Projekt dropbar sein

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.2] - 2026-04-20
+
+### Fixed
+- Custom `accent` in `chapters.json` now propagates consistently across all UI states (#33):
+  - Five hardcoded `rgba(232,121,29,...)` sites (selection, search-glow, sidebar-active, TOC-active, code-highlight) replaced with `color-mix(in srgb, var(--help-accent) XX%, transparent)` so tints track the override
+  - `--help-accent-deep` and `--help-accent-light` now derived from `var(--help-accent)` via `color-mix()` instead of hardcoded orange tones — fixes light-mode text reverting to default orange when a custom accent is set
+
 ## [2.2.0] - 2026-04-19
 
 ### Added
@@ -125,7 +132,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Light mode code blocks and prev/next navigation bug
 - Dark mode: neutral gray/black instead of blue-tinted Catppuccin
 
-[Unreleased]: https://github.com/leminkozey/help-book/compare/v2.1.0...HEAD
+[Unreleased]: https://github.com/leminkozey/help-book/compare/v2.2.2...HEAD
+[2.2.2]: https://github.com/leminkozey/help-book/compare/v2.2.0...v2.2.2
+[2.2.0]: https://github.com/leminkozey/help-book/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/leminkozey/help-book/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/leminkozey/help-book/compare/v1.1.0...v2.0.0
 [1.1.0]: https://github.com/leminkozey/help-book/compare/v1.0.0...v1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-04-20
+
+Audit pass driven by `impeccable /audit` — addresses every P0/P1/P2/P3 finding. No breaking changes to the public surface (accent, CSP, `chapters.json` schema, install.sh).
+
+### Added
+- **Collapsible "On this page" TOC for mobile viewports** (`<details>` element in `.help-content`). The header TOC bar used to disappear under 768px with no replacement, leaving long chapters unnavigable on phones.
+
+### Changed
+- **Typography swap**: Inter → **Geist Sans** as the body/UI face. Inter is on every "default AI font" list; Geist pairs naturally with the already-loaded Geist Mono.
+- **Article width capped at 72ch + 64px** padding. Body text on wide monitors used to wrap at 100+ chars; content still anchors left against the sidebar.
+- **H4 scale opened**: 16 → 18px. Previous scale had H4 = body size, distinguished only by weight; the new ratio matches the ~1.25 step used elsewhere.
+- **Accent shades are now theme-aware**: `--help-accent-deep` / `--help-accent-light` redefine themselves under `[data-theme="dark"]`. Six `[data-theme="dark"]` override blocks collapsed into the token definition.
+- **Scrollbar tinted toward brand accent** (`color-mix` with accent at 6%/10%).
+- **Sidebar-header divider removed** — replaced 1px border-bottom with whitespace (DESIGN.md already mandated no dividers).
+- **Search input width no longer animates on focus** — animating width forces a reflow every frame. Input sized for its typical content across three breakpoints.
+
+### Fixed
+- **Blockquote border-left stripe removed** (impeccable BAN 1). Full background tint + italic now signal the quote; the 3px accent side-stripe is the #1 AI-design tell in admin/doc UIs.
+- **`--help-text-tertiary` lifted to WCAG AA 4.5:1**: `#888` → `#6e6e6e` on light, `#888` → `#9a9a9a` on dark. Affects footer (11px), prev/next labels, copy-button label.
+- **H1 mobile letter-spacing** (`-0.4px` at 28px) — previously missing while 40px and 32px both had tracking.
+
+### Accessibility
+- **Interactive targets enlarged**: nav-item 30 → 36px (mobile 44px), TOC-bar link 32 → 36px, copy-button 28 → 32px (mobile 44px). WCAG 2.5.5 compliant on touch.
+
 ## [2.2.2] - 2026-04-20
 
 ### Fixed
@@ -132,7 +156,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Light mode code blocks and prev/next navigation bug
 - Dark mode: neutral gray/black instead of blue-tinted Catppuccin
 
-[Unreleased]: https://github.com/leminkozey/help-book/compare/v2.2.2...HEAD
+[Unreleased]: https://github.com/leminkozey/help-book/compare/v2.3.0...HEAD
+[2.3.0]: https://github.com/leminkozey/help-book/compare/v2.2.2...v2.3.0
 [2.2.2]: https://github.com/leminkozey/help-book/compare/v2.2.0...v2.2.2
 [2.2.0]: https://github.com/leminkozey/help-book/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/leminkozey/help-book/compare/v2.0.0...v2.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ Audit pass driven by `impeccable /audit` — addresses every P0/P1/P2/P3 finding
 ### Accessibility
 - **Interactive targets enlarged**: nav-item 30 → 36px (mobile 44px), TOC-bar link 32 → 36px, copy-button 28 → 32px (mobile 44px). WCAG 2.5.5 compliant on touch.
 
+### Polish
+- `.help-content` max-width now fluid via `clamp(72ch, 62vw, 84ch)` so ultra-wide viewports gain breathing room while 1024-1440 stays at the 72ch readability target.
+- Heading scale opened: H1 40 → 44, H2 24 → 26, H3 stays 20 (H2/H3 ratio now 1.30, ≥1.25 target). H4 repurposed as uppercase muted eyebrow label since a 4th size level is rarely earned in docs.
+- `<ol>` / `<ul>` markers now use the brand accent for subtle cohesion.
+- Inline `<code>` gains a 1px border for clearer boundary against body text.
+
 ## [2.2.2] - 2026-04-20
 
 ### Fixed

--- a/help/chapters.json
+++ b/help/chapters.json
@@ -1,6 +1,6 @@
 {
   "title": "Help Book Demo",
-  "version": "v2.2.1",
+  "version": "v2.2.2",
   "accent": "#e8791d",
   "chapters": [
     {

--- a/help/chapters.json
+++ b/help/chapters.json
@@ -1,6 +1,6 @@
 {
   "title": "Help Book Demo",
-  "version": "v2.2.2",
+  "version": "v2.3.0",
   "accent": "#e8791d",
   "chapters": [
     {

--- a/help/help.css
+++ b/help/help.css
@@ -483,6 +483,65 @@ body {
 
 .help-toc-bar a.active .toc-dot { background: var(--help-accent); }
 
+.help-toc-mobile {
+  display: none;
+  margin: 8px 0 24px;
+  padding: 12px 16px;
+  background: var(--help-bg-secondary);
+  border-radius: var(--help-radius-lg);
+  font-family: var(--help-font-sans);
+  font-size: 14px;
+}
+
+.help-toc-mobile[hidden] { display: none; }
+
+.help-toc-mobile summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--help-text);
+  list-style: none;
+  padding: 4px 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 32px;
+}
+
+.help-toc-mobile summary::-webkit-details-marker { display: none; }
+
+.help-toc-mobile summary::after {
+  content: '';
+  width: 8px;
+  height: 8px;
+  border-right: 1.5px solid var(--help-text-muted);
+  border-bottom: 1.5px solid var(--help-text-muted);
+  transform: rotate(45deg);
+  margin-left: auto;
+  margin-right: 4px;
+  transition: transform 0.15s;
+}
+
+.help-toc-mobile[open] summary::after { transform: rotate(-135deg); margin-top: 4px; }
+
+.help-toc-mobile-list {
+  list-style: decimal inside;
+  margin: 12px 0 4px;
+  padding: 0;
+  color: var(--help-text-muted);
+}
+
+.help-toc-mobile-list li { margin: 6px 0; padding-left: 4px; }
+
+.help-toc-mobile-list a {
+  color: var(--help-text-body);
+  text-decoration: none;
+  min-height: 32px;
+  display: inline-flex;
+  align-items: center;
+}
+
+.help-toc-mobile-list a:hover { color: var(--help-accent); }
+
 .help-article {
   font-family: var(--help-font-sans);
   font-size: 16px;
@@ -782,6 +841,7 @@ body {
   .help-sidebar-toggle { display: flex; }
 
   .help-toc-bar { display: none !important; }
+  .help-toc-mobile:not([hidden]) { display: block; }
 
   .help-sidebar {
     left: 0;

--- a/help/help.css
+++ b/help/help.css
@@ -40,8 +40,8 @@
   --help-font-sans: 'Geist', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   --help-font-mono: 'Geist Mono', ui-monospace, SFMono-Regular, 'JetBrains Mono', Menlo, monospace;
 
-  --help-scrollbar: #e5e5e5;
-  --help-scrollbar-hover: #888888;
+  --help-scrollbar: color-mix(in srgb, var(--help-accent) 6%, #e5e5e5);
+  --help-scrollbar-hover: color-mix(in srgb, var(--help-accent) 35%, #888);
 }
 
 [data-theme="dark"] {
@@ -73,8 +73,8 @@
   --help-shadow-button: 0 1px 2px rgba(0,0,0,0.6);
   --help-shadow-pop: 0 8px 24px rgba(0,0,0,0.5);
 
-  --help-scrollbar: #2a2a2a;
-  --help-scrollbar-hover: #4a4a4a;
+  --help-scrollbar: color-mix(in srgb, var(--help-accent) 10%, #2a2a2a);
+  --help-scrollbar-hover: color-mix(in srgb, var(--help-accent) 35%, #4a4a4a);
 }
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/help/help.css
+++ b/help/help.css
@@ -406,6 +406,7 @@ body {
 
 .help-content {
   min-width: 0;
+  max-width: calc(72ch + 64px);
   padding: 28px 48px 64px 16px;
   outline: none;
 }

--- a/help/help.css
+++ b/help/help.css
@@ -393,8 +393,8 @@ body {
 
 .help-content {
   min-width: 0;
-  max-width: calc(72ch + 64px);
-  padding: 28px 48px 64px 16px;
+  max-width: clamp(calc(72ch + 64px), 62vw, calc(84ch + 64px));
+  padding: 32px 56px 72px 16px;
   outline: none;
 }
 
@@ -544,38 +544,40 @@ body {
 }
 
 .help-article h1 {
-  font-size: 40px;
+  font-size: 44px;
   font-weight: 600;
-  line-height: 1.10;
-  letter-spacing: -0.8px;
-  margin-bottom: 24px;
+  line-height: 1.08;
+  letter-spacing: -0.9px;
+  margin-bottom: 28px;
 }
 
 .help-article h2 {
-  font-size: 24px;
+  font-size: 26px;
   font-weight: 600;
-  line-height: 1.30;
-  letter-spacing: -0.24px;
-  margin-top: 56px;
+  line-height: 1.28;
+  letter-spacing: -0.26px;
+  margin-top: 64px;
   margin-bottom: 16px;
 }
 
 .help-article h3 {
   font-size: 20px;
   font-weight: 600;
-  line-height: 1.30;
+  line-height: 1.32;
   letter-spacing: -0.2px;
-  margin-top: 32px;
+  margin-top: 40px;
   margin-bottom: 8px;
 }
 
 .help-article h4 {
-  font-size: 18px;
+  font-size: 16px;
   font-weight: 600;
-  line-height: 1.40;
-  letter-spacing: -0.1px;
-  margin-top: 24px;
-  margin-bottom: 8px;
+  line-height: 1.45;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: var(--help-text-muted);
+  margin-top: 32px;
+  margin-bottom: 6px;
 }
 
 .help-article p {
@@ -605,9 +607,10 @@ body {
   padding-left: 24px;
 }
 
-.help-article li { margin-bottom: 6px; }
+.help-article li { margin-bottom: 8px; }
+.help-article li::marker { color: var(--help-accent); }
 .help-article li > ul,
-.help-article li > ol { margin-top: 6px; margin-bottom: 0; }
+.help-article li > ol { margin-top: 8px; margin-bottom: 0; }
 
 .help-article blockquote {
   margin: 24px 0;
@@ -641,6 +644,7 @@ body {
   color: var(--help-text);
   padding: 2px 6px;
   border-radius: var(--help-radius-sm);
+  border: 1px solid var(--help-border);
 }
 
 .help-article pre {
@@ -850,9 +854,9 @@ body {
     right: 16px;
   }
 
-  .help-article h1 { font-size: 32px; letter-spacing: -0.6px; }
-  .help-article h2 { font-size: 20px; letter-spacing: -0.2px; margin-top: 36px; }
-  .help-article h3 { font-size: 18px; }
+  .help-article h1 { font-size: 34px; letter-spacing: -0.7px; margin-bottom: 24px; }
+  .help-article h2 { font-size: 22px; letter-spacing: -0.22px; margin-top: 48px; }
+  .help-article h3 { font-size: 18px; margin-top: 32px; }
 
   .help-prev-next { flex-direction: column; }
   .help-prev-next a { max-width: 100%; }

--- a/help/help.css
+++ b/help/help.css
@@ -45,6 +45,9 @@
 }
 
 [data-theme="dark"] {
+  --help-accent-deep: var(--help-accent);
+  --help-accent-light: color-mix(in srgb, var(--help-accent) 14%, transparent);
+
   --help-bg: #1c1c1e;
   --help-bg-secondary: #242426;
   --help-card-bg: #2c2c2e;
@@ -96,11 +99,6 @@ body {
 ::selection {
   background: var(--help-accent-light);
   color: var(--help-accent-deep);
-}
-
-[data-theme="dark"] ::selection {
-  background: color-mix(in srgb, var(--help-accent) 25%, transparent);
-  color: var(--help-accent);
 }
 
 ::-webkit-scrollbar { width: 8px; height: 8px; }
@@ -285,11 +283,6 @@ body {
   padding: 0 2px;
 }
 
-[data-theme="dark"] .help-search-result-snippet mark {
-  background: color-mix(in srgb, var(--help-accent) 20%, transparent);
-  color: var(--help-accent);
-}
-
 .help-search-empty {
   padding: 16px;
   text-align: center;
@@ -373,11 +366,6 @@ body {
   color: var(--help-accent-deep);
   font-weight: 600;
   background: var(--help-accent-light);
-}
-
-[data-theme="dark"] .help-nav-item.active {
-  color: var(--help-accent);
-  background: color-mix(in srgb, var(--help-accent) 12%, transparent);
 }
 
 .help-nav-group-toggle { font-weight: 600; }
@@ -465,11 +453,6 @@ body {
 .help-toc-bar a.active {
   color: var(--help-accent-deep);
   background: var(--help-accent-light);
-}
-
-[data-theme="dark"] .help-toc-bar a.active {
-  color: var(--help-accent);
-  background: color-mix(in srgb, var(--help-accent) 12%, transparent);
 }
 
 .help-toc-bar .toc-dot {
@@ -615,10 +598,6 @@ body {
 .help-article a:hover {
   color: var(--help-accent-deep);
   text-decoration-color: var(--help-accent);
-}
-
-[data-theme="dark"] .help-article a:hover {
-  color: var(--help-accent);
 }
 
 .help-article ul,
@@ -782,7 +761,6 @@ body {
 }
 
 .help-footer a:hover { color: var(--help-accent-deep); }
-[data-theme="dark"] .help-footer a:hover { color: var(--help-accent); }
 
 .help-prev-next {
   display: flex;

--- a/help/help.css
+++ b/help/help.css
@@ -343,8 +343,9 @@ body {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 7px 12px;
-  margin: 1px 0;
+  padding: 8px 12px;
+  min-height: 36px;
+  margin: 2px 0;
   color: var(--help-text-body);
   text-decoration: none;
   font-family: var(--help-font-sans);
@@ -438,9 +439,9 @@ body {
   position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  height: 32px;
+  gap: 8px;
+  padding: 8px 12px;
+  min-height: 36px;
   color: var(--help-text-muted);
   text-decoration: none;
   font-family: var(--help-font-sans);
@@ -631,13 +632,13 @@ body {
 
 .help-copy-btn {
   position: absolute;
-  top: 10px;
-  right: 10px;
+  top: 8px;
+  right: 8px;
   background: var(--help-bg);
   border: 1px solid var(--help-border-strong);
   color: var(--help-text-muted);
-  padding: 4px 12px;
-  min-height: 28px;
+  padding: 6px 14px;
+  min-height: 32px;
   border-radius: var(--help-radius-pill);
   font-family: var(--help-font-mono);
   font-size: 11px;
@@ -801,6 +802,9 @@ body {
   body:has(.help-sidebar.open) .help-sidebar-overlay { display: block; }
 
   .help-content { padding: 24px 20px 64px; max-width: 100%; }
+
+  .help-nav-item { min-height: 44px; padding: 10px 12px; }
+  .help-copy-btn { min-height: 44px; padding: 10px 16px; }
 
   .help-search { width: 160px; }
   .help-search:focus { width: 200px; }

--- a/help/help.css
+++ b/help/help.css
@@ -37,7 +37,7 @@
   --help-radius-xl: 24px;
   --help-radius-pill: 9999px;
 
-  --help-font-sans: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --help-font-sans: 'Geist', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   --help-font-mono: 'Geist Mono', ui-monospace, SFMono-Regular, 'JetBrains Mono', Menlo, monospace;
 
   --help-scrollbar: #e5e5e5;

--- a/help/help.css
+++ b/help/help.css
@@ -201,7 +201,7 @@ body {
 }
 
 .help-search {
-  width: 220px;
+  width: 260px;
   padding: 8px 16px;
   border: 1px solid var(--help-border-strong);
   border-radius: var(--help-radius-pill);
@@ -210,7 +210,7 @@ body {
   font-family: var(--help-font-sans);
   font-size: 14px;
   font-weight: 400;
-  transition: border-color 0.15s, width 0.2s, box-shadow 0.15s;
+  transition: border-color 0.15s, box-shadow 0.15s;
 }
 
 .help-search::placeholder { color: var(--help-text-tertiary); }
@@ -219,7 +219,6 @@ body {
 
 .help-search:focus {
   border-color: var(--help-accent);
-  width: 280px;
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--help-accent) 15%, transparent);
 }
 
@@ -806,8 +805,7 @@ body {
   .help-nav-item { min-height: 44px; padding: 10px 12px; }
   .help-copy-btn { min-height: 44px; padding: 10px 16px; }
 
-  .help-search { width: 160px; }
-  .help-search:focus { width: 200px; }
+  .help-search { width: 200px; }
 
   .help-search-results {
     width: 320px;
@@ -831,8 +829,7 @@ body {
     gap: 8px;
   }
   .help-content { padding: 24px 16px; }
-  .help-search { width: 120px; padding: 7px 12px; }
-  .help-search:focus { width: 160px; }
+  .help-search { width: 148px; padding: 8px 12px; }
   .help-article h1 { font-size: 28px; }
 }
 

--- a/help/help.css
+++ b/help/help.css
@@ -14,7 +14,7 @@
   --help-text: #0d0d0d;
   --help-text-body: #333333;
   --help-text-muted: #666666;
-  --help-text-tertiary: #888888;
+  --help-text-tertiary: #6e6e6e;
 
   --help-border: rgba(0,0,0,0.05);
   --help-border-strong: rgba(0,0,0,0.08);
@@ -56,7 +56,7 @@
   --help-text: #ededed;
   --help-text-body: #d4d4d4;
   --help-text-muted: #a0a0a0;
-  --help-text-tertiary: #888888;
+  --help-text-tertiary: #9a9a9a;
 
   --help-border: rgba(255,255,255,0.08);
   --help-border-strong: rgba(255,255,255,0.12);

--- a/help/help.css
+++ b/help/help.css
@@ -571,12 +571,12 @@ body {
 .help-article li > ol { margin-top: 6px; margin-bottom: 0; }
 
 .help-article blockquote {
-  border-left: 3px solid var(--help-accent);
   margin: 24px 0;
-  padding: 12px 20px;
+  padding: 16px 24px;
   background: var(--help-bg-secondary);
-  border-radius: 0 var(--help-radius-lg) var(--help-radius-lg) 0;
+  border-radius: var(--help-radius-lg);
   color: var(--help-text-muted);
+  font-style: italic;
 }
 
 .help-article blockquote p:last-child { margin-bottom: 0; }

--- a/help/help.css
+++ b/help/help.css
@@ -529,11 +529,12 @@ body {
 }
 
 .help-article h4 {
-  font-size: 16px;
+  font-size: 18px;
   font-weight: 600;
-  line-height: 1.50;
+  line-height: 1.40;
+  letter-spacing: -0.1px;
   margin-top: 24px;
-  margin-bottom: 6px;
+  margin-bottom: 8px;
 }
 
 .help-article p {

--- a/help/help.css
+++ b/help/help.css
@@ -1,7 +1,7 @@
 :root {
   --help-accent: #e8791d;
-  --help-accent-deep: #c2620f;
-  --help-accent-light: #fde2cc;
+  --help-accent-deep: color-mix(in srgb, var(--help-accent) 80%, #000);
+  --help-accent-light: color-mix(in srgb, var(--help-accent) 22%, #fff);
 
   --help-bg: #f5f5f7;
   --help-bg-secondary: #eeeef0;
@@ -99,7 +99,7 @@ body {
 }
 
 [data-theme="dark"] ::selection {
-  background: rgba(232,121,29,0.25);
+  background: color-mix(in srgb, var(--help-accent) 25%, transparent);
   color: var(--help-accent);
 }
 
@@ -220,7 +220,7 @@ body {
 .help-search:focus {
   border-color: var(--help-accent);
   width: 280px;
-  box-shadow: 0 0 0 3px rgba(232,121,29,0.15);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--help-accent) 15%, transparent);
 }
 
 .help-search:focus-visible {
@@ -287,7 +287,7 @@ body {
 }
 
 [data-theme="dark"] .help-search-result-snippet mark {
-  background: rgba(232,121,29,0.2);
+  background: color-mix(in srgb, var(--help-accent) 20%, transparent);
   color: var(--help-accent);
 }
 
@@ -377,7 +377,7 @@ body {
 
 [data-theme="dark"] .help-nav-item.active {
   color: var(--help-accent);
-  background: rgba(232,121,29,0.12);
+  background: color-mix(in srgb, var(--help-accent) 12%, transparent);
 }
 
 .help-nav-group-toggle { font-weight: 600; }
@@ -468,7 +468,7 @@ body {
 
 [data-theme="dark"] .help-toc-bar a.active {
   color: var(--help-accent);
-  background: rgba(232,121,29,0.12);
+  background: color-mix(in srgb, var(--help-accent) 12%, transparent);
 }
 
 .help-toc-bar .toc-dot {

--- a/help/help.css
+++ b/help/help.css
@@ -125,12 +125,11 @@ body {
 }
 
 .help-sidebar-header {
-  padding: 4px 12px 16px;
-  margin-bottom: 8px;
-  border-bottom: 1px solid var(--help-border);
+  padding: 4px 12px 20px;
+  margin-bottom: 4px;
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
 }
 
 .help-logo {
@@ -868,7 +867,7 @@ body {
   }
   .help-content { padding: 24px 16px; }
   .help-search { width: 148px; padding: 8px 12px; }
-  .help-article h1 { font-size: 28px; }
+  .help-article h1 { font-size: 28px; letter-spacing: -0.4px; }
 }
 
 .help-skip-link {

--- a/help/help.js
+++ b/help/help.js
@@ -13,6 +13,8 @@
   var $nav      = document.querySelector('.help-nav');
   var $article  = document.querySelector('.help-article');
   var $toc      = document.querySelector('.help-toc-bar');
+  var $tocMobile     = document.querySelector('.help-toc-mobile');
+  var $tocMobileList = document.querySelector('.help-toc-mobile-list');
   var $footer   = document.querySelector('.help-footer');
   var $sidebar  = document.querySelector('.help-sidebar');
   var $overlay  = document.querySelector('.help-sidebar-overlay');
@@ -303,6 +305,8 @@
     if (headings.length < 2) {
       $toc.classList.remove('active');
       $toc.innerHTML = '';
+      if ($tocMobile) $tocMobile.hidden = true;
+      if ($tocMobileList) $tocMobileList.innerHTML = '';
       // release lock that navigate() set, since initScrollSpy() won't run to release it
       requestAnimationFrame(function () { scrollSpyLocked = false; });
       return;
@@ -310,6 +314,7 @@
 
     var inner = document.createElement('div');
     inner.className = 'help-toc-bar-inner';
+    if ($tocMobileList) $tocMobileList.innerHTML = '';
     headings.forEach(function (h) {
       var a = document.createElement('a');
       a.href = '#' + h.id;
@@ -318,24 +323,48 @@
       inner.appendChild(a);
       tocLinks.push(a);
       tocLinkMap[h.id] = a;
+
+      if ($tocMobileList) {
+        var li = document.createElement('li');
+        var mobileLink = document.createElement('a');
+        mobileLink.href = '#' + h.id;
+        mobileLink.dataset.headingId = h.id;
+        mobileLink.textContent = h.textContent;
+        li.appendChild(mobileLink);
+        $tocMobileList.appendChild(li);
+      }
     });
 
     $toc.innerHTML = '';
     $toc.appendChild(inner);
     $toc.classList.add('active');
+    if ($tocMobile) $tocMobile.hidden = false;
 
     initScrollSpy(headings);
   }
 
   function initTocDelegation() {
-    if (!$toc) return;
-    $toc.addEventListener('click', function (e) {
-      var a = e.target.closest('a[data-heading-id]');
-      if (!a || !$toc.contains(a)) return;
-      e.preventDefault();
-      setActiveTocLink(a);
-      scrollToHeading(a.dataset.headingId);
-    });
+    if ($toc) {
+      $toc.addEventListener('click', function (e) {
+        var a = e.target.closest('a[data-heading-id]');
+        if (!a || !$toc.contains(a)) return;
+        e.preventDefault();
+        setActiveTocLink(a);
+        scrollToHeading(a.dataset.headingId);
+      });
+    }
+    if ($tocMobileList) {
+      $tocMobileList.addEventListener('click', function (e) {
+        var a = e.target.closest('a[data-heading-id]');
+        if (!a) return;
+        e.preventDefault();
+        var headingId = a.dataset.headingId;
+        var headerLink = tocLinkMap[headingId];
+        if (headerLink) setActiveTocLink(headerLink);
+        scrollToHeading(headingId);
+        if ($tocMobile) $tocMobile.open = false;
+      });
+    }
   }
 
   function scrollToHeading(id) {

--- a/help/index.html
+++ b/help/index.html
@@ -9,7 +9,7 @@
   <link rel="icon" type="image/svg+xml" href="logo.svg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Geist+Mono:wght@400;500;600&display=swap">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600&family=Geist+Mono:wght@400;500;600&display=swap">
   <link rel="stylesheet" href="help.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css" integrity="sha384-eFTL69TLRZTkNfYZOLM+G04821K1qZao/4QLJbet1pP4tcF+fdXq/9CdqAbWRl/L" crossorigin="anonymous" referrerpolicy="no-referrer" id="hljs-light">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css" integrity="sha384-wH75j6z1lH97ZOpMOInqhgKzFkAInZPPSPlZpYKYTOqsaizPvhQZmAtLcPKXpLyH" crossorigin="anonymous" referrerpolicy="no-referrer" id="hljs-dark" disabled>

--- a/help/index.html
+++ b/help/index.html
@@ -60,6 +60,10 @@
     <div class="help-sidebar-overlay"></div>
 
     <main class="help-content" id="main" tabindex="-1">
+      <details class="help-toc-mobile" hidden>
+        <summary>On this page</summary>
+        <ol class="help-toc-mobile-list"></ol>
+      </details>
       <article class="help-article"></article>
       <footer class="help-footer"></footer>
     </main>


### PR DESCRIPTION
## Summary

Full `/impeccable audit` sweep — score 14/20 → 20/20. Every P0/P1/P2/P3 finding addressed on a single branch.

Re-opens of #35 after PR #34 (accent-fix) merged and auto-closed this one.

### P0 / P1 — Anti-Patterns & A11y
- Removed blockquote accent border-stripe (BAN 1 — the #1 AI-design tell)
- Swapped Inter → **Geist Sans** body face (Inter is on every "reflex AI font" list; Geist pairs naturally with the already-loaded Geist Mono)
- Lifted `--help-text-tertiary` to WCAG AA 4.5:1 (`#888` → `#6e6e6e` / `#9a9a9a`)
- Interactive targets enlarged to WCAG 2.5.5 (nav-item 36px, TOC-bar 36px, copy-btn 32px; all 44px on mobile)

### P2 — Layout / Typography
- Content max-width capped at `clamp(72ch, 62vw, 84ch)` + 64px padding
- Heading scale opened (H1 40→44, H2 24→26; H4 repurposed as uppercase muted eyebrow)
- H4 scale step opened (16→18px) on the old scale before H4 became an eyebrow
- Mobile `<details>` TOC — header TOC bar used to disappear under 768px with no replacement

### P3 — Polish
- Accent shades now theme-aware via `[data-theme="dark"]` token override (collapsed 6 dark-mode override blocks)
- Scrollbar tinted with brand accent (`color-mix` 6%/10%)
- Sidebar-header divider removed (DESIGN.md mandated no dividers)
- Search input width no longer animates on focus (reflow cost)
- H1 mobile letter-spacing filled in
- `<ol>`/`<ul>` markers use brand accent
- Inline `<code>` gets 1px border for clearer boundary

### Seeded
- `.impeccable.md` — design context file for future audit runs (skill auto-loads it)

## Test plan
- [x] `python3 -m http.server 8082` on `help/` locally
- [x] Playwright screenshots at 1920 (light), 1440 (dark), 390 (mobile)
- [x] All 4 demo chapters render (markdown → HTML → highlight.js)
- [x] Custom accent color in chapters.json still propagates (from #33 fix, which is included via main merge)
- [ ] Live demo at github.io once merged + tagged