### PR TITLE
feat: configurable Edit-on-GitHub link via editUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Configurable "Edit this page on GitHub" link via `editUrl` in `chapters.json`
+
 ## [2.4.0] - 2026-04-20
 
 Install/update ergonomics: one-shot update command, automatic rollback snapshot. No breaking changes — existing installs keep working unchanged until they update once.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Everything is configured in `chapters.json`:
 | `title` | Header and browser tab title |
 | `version` | Shown in footer (optional) |
 | `accent` | CSS accent color — accepts hex, `rgb(...)`, `hsl(...)`, `oklch(...)` (default: warm orange `#e8791d`) |
+| `editUrl` | Optional URL template for an "Edit this page on GitHub" link rendered under each chapter. Use `{file}` as a placeholder for the chapter's `file` value, e.g. `https://github.com/you/repo/edit/main/help/{file}`. Omit the key to hide the link. |
 | `chapters` | Ordered list of chapter objects |
 
 Chapters can be nested one level deep. Parent chapters can optionally have their own `file`.

--- a/help/chapters.json
+++ b/help/chapters.json
@@ -2,6 +2,7 @@
   "title": "Help Book Demo",
   "version": "v2.4.0",
   "accent": "#e8791d",
+  "editUrl": "https://github.com/leminkozey/help-book/edit/main/help/{file}",
   "chapters": [
     {
       "id": "getting-started",

--- a/help/help.css
+++ b/help/help.css
@@ -765,6 +765,34 @@ body {
 
 .help-footer a:hover { color: var(--help-accent-deep); }
 
+.help-edit-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 40px;
+  font-family: var(--help-font-sans);
+  font-size: 13px;
+  color: var(--help-text-muted);
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.help-edit-link:hover {
+  color: var(--help-text);
+  text-decoration: underline;
+}
+
+.help-edit-link:focus-visible {
+  outline: 2px solid var(--help-accent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+.help-edit-link-icon {
+  flex-shrink: 0;
+  opacity: 0.85;
+}
+
 .help-prev-next {
   display: flex;
   justify-content: space-between;

--- a/help/help.js
+++ b/help/help.js
@@ -194,9 +194,8 @@
         scrollSpyLocked = true;
         renderMarkdown(md);
         buildToc();
-        // prev/next zuerst, danach edit-link via $article.after() — so landet
-        // edit-link zwischen article und prev/next
         buildPrevNext();
+        // edit-link nach prev/next aufbauen — $article.after() schiebt ihn dann zwischen article und prev/next ein
         buildEditLink();
         window.scrollTo(0, 0);
         if ($main && typeof $main.focus === 'function') {
@@ -431,14 +430,13 @@
     var ch = chapters.find(function (c) { return c.id === currentId; });
     if (!ch || !ch.file) return;
 
-    // {file} platzhalter ersetzen
     var url = editUrlTemplate.replace(/\{file\}/g, encodeURI(ch.file));
 
     var a = document.createElement('a');
     a.className = 'help-edit-link';
     a.href = url;
     a.target = '_blank';
-    a.rel = 'noopener';
+    a.rel = 'noopener noreferrer';
     a.innerHTML =
       '<svg class="help-edit-link-icon" width="14" height="14" viewBox="0 0 24 24" ' +
       'fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" ' +

--- a/help/help.js
+++ b/help/help.js
@@ -5,6 +5,7 @@
   // hold full markdown for every chapter — search needs full text, dropping would force re-fetches
   var chapterTexts = Object.create(null);
   var currentId = null;
+  var editUrlTemplate = '';
   var chaptersReady = false;
   var activeNavEl = null;
   var scrollHeadingTimer = null;
@@ -55,6 +56,9 @@
         }
         $title.textContent = data.title || 'Help';
         document.title = data.title || 'Help';
+        if (typeof data.editUrl === 'string' && /^https?:\/\//i.test(data.editUrl)) {
+          editUrlTemplate = data.editUrl;
+        }
         buildNav(data.chapters, $nav);
         flattenChapters(data.chapters);
         preloadChapters();
@@ -190,7 +194,10 @@
         scrollSpyLocked = true;
         renderMarkdown(md);
         buildToc();
+        // prev/next zuerst, danach edit-link via $article.after() — so landet
+        // edit-link zwischen article und prev/next
         buildPrevNext();
+        buildEditLink();
         window.scrollTo(0, 0);
         if ($main && typeof $main.focus === 'function') {
           $main.focus({ preventScroll: true });
@@ -415,6 +422,32 @@
     requestAnimationFrame(function () {
       requestAnimationFrame(function () { scrollSpyLocked = false; });
     });
+  }
+
+  function buildEditLink() {
+    var old = document.querySelector('.help-edit-link');
+    if (old) old.remove();
+    if (!editUrlTemplate) return;
+    var ch = chapters.find(function (c) { return c.id === currentId; });
+    if (!ch || !ch.file) return;
+
+    // {file} platzhalter ersetzen
+    var url = editUrlTemplate.replace(/\{file\}/g, encodeURI(ch.file));
+
+    var a = document.createElement('a');
+    a.className = 'help-edit-link';
+    a.href = url;
+    a.target = '_blank';
+    a.rel = 'noopener';
+    a.innerHTML =
+      '<svg class="help-edit-link-icon" width="14" height="14" viewBox="0 0 24 24" ' +
+      'fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" ' +
+      'stroke-linejoin="round" aria-hidden="true">' +
+      '<path d="M12 20h9"/>' +
+      '<path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z"/>' +
+      '</svg>' +
+      '<span>Edit this page on GitHub</span>';
+    $article.after(a);
   }
 
   function buildPrevNext() {


### PR DESCRIPTION
Adds optional `editUrl` to `chapters.json` with `{file}` placeholder. Renders a muted "Edit this page on GitHub" link (inline pencil SVG) between article and prev/next nav. Absent/empty editUrl silently renders nothing.

**Files:** `help/help.js`, `help/help.css`, `help/chapters.json`, `README.md`, `CHANGELOG.md` (Unreleased / Added).

## Test plan
- [ ] Set `editUrl` -> link appears at chapter bottom
- [ ] Remove `editUrl` -> no link rendered
- [ ] Link opens in new tab