### PR TITLE
feat: heading anchor links (H2/H3 copy section URL on click)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Configurable "Edit this page on GitHub" link via `editUrl` in `chapters.json`
+- Heading anchor links: hover H2/H3 to reveal a # icon that copies the section URL.
 
 ## [2.4.0] - 2026-04-20
 

--- a/help/help.css
+++ b/help/help.css
@@ -543,6 +543,84 @@ body {
   scroll-margin-top: calc(var(--help-header-h) + 16px);
 }
 
+/* heading anchor — hidden until hover, reveals a # for copying section link */
+.help-article h2,
+.help-article h3 { position: relative; }
+
+.help-heading-anchor {
+  position: absolute;
+  right: 100%;
+  top: 0;
+  bottom: 0;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 10px;
+  margin-right: 2px;
+  color: var(--help-text-tertiary);
+  text-decoration: none;
+  font-weight: 400;
+  font-size: 0.7em;
+  line-height: 1;
+  opacity: 0;
+  transition: opacity 0.15s, color 0.15s;
+  user-select: none;
+}
+
+.help-article h2:hover .help-heading-anchor,
+.help-article h3:hover .help-heading-anchor,
+.help-article h2:focus-within .help-heading-anchor,
+.help-article h3:focus-within .help-heading-anchor,
+.help-heading-anchor:hover,
+.help-heading-anchor:focus-visible {
+  opacity: 1;
+}
+
+.help-heading-anchor:hover { color: var(--help-text); }
+
+.help-heading-anchor:focus-visible {
+  outline: 2px solid var(--help-accent);
+  outline-offset: 2px;
+  border-radius: var(--help-radius-sm);
+}
+
+/* touch devices: hover is unreliable — keep anchor permanently visible at low contrast */
+@media (pointer: coarse) {
+  .help-heading-anchor { opacity: 0.5; }
+}
+
+/* on narrow viewports the left gutter disappears — push anchor inline before the text */
+@media (max-width: 768px) {
+  .help-heading-anchor {
+    position: static;
+    padding: 0 6px 0 0;
+    margin-right: 4px;
+  }
+}
+
+.help-toast {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translate(-50%, 12px);
+  padding: 10px 18px;
+  background: var(--help-text);
+  color: var(--help-bg);
+  font-family: var(--help-font-sans);
+  font-size: 13px;
+  font-weight: 500;
+  border-radius: var(--help-radius-pill);
+  box-shadow: var(--help-shadow-pop);
+  opacity: 0;
+  pointer-events: none;
+  z-index: 1000;
+  transition: opacity 0.18s, transform 0.18s;
+}
+
+.help-toast.visible {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
 .help-article h1 {
   font-size: 44px;
   font-weight: 600;

--- a/help/help.js
+++ b/help/help.js
@@ -309,7 +309,7 @@
       var a = document.createElement('a');
       a.className = 'help-heading-anchor';
       a.href = '#' + encodeURIComponent(currentId) + '--' + encodeURIComponent(h.id);
-      a.setAttribute('aria-label', 'Link zu diesem Abschnitt kopieren');
+      a.setAttribute('aria-label', 'Copy link to this section');
       a.dataset.headingAnchor = h.id;
       a.textContent = '#';
       h.insertBefore(a, h.firstChild);
@@ -326,16 +326,16 @@
         if (!headingId || !currentId) return;
         var hash = '#' + encodeURIComponent(currentId) + '--' + encodeURIComponent(headingId);
         var url = location.origin + location.pathname + location.search + hash;
-        // replaceState so hash change doesn't pile up in history and skip the hashchange handler
+        // replaceState updates the URL without a history entry and without firing hashchange — avoids re-running navigate()
         history.replaceState(null, '', url);
         if (navigator.clipboard && navigator.clipboard.writeText) {
           navigator.clipboard.writeText(url).then(function () {
-            showToast('Link kopiert');
+            showToast('Link copied');
           }).catch(function () {
-            showToast('Link kopiert');
+            showToast('Copy failed — link is in the address bar');
           });
         } else {
-          showToast('Link kopiert');
+          showToast('Link is in the address bar');
         }
         return;
       }

--- a/help/help.js
+++ b/help/help.js
@@ -163,7 +163,7 @@
     }
   }
 
-  function navigate(id) {
+  function navigate(id, headingId) {
     var ch = chapters.find(function (c) { return c.id === id; });
     if (!ch) {
       if (chapters.length > 0) navigate(chapters[0].id);
@@ -172,8 +172,14 @@
 
     // set currentId before hash update so hashchange handler can bail without redundant fetch
     currentId = id;
-    if (window.location.hash.slice(1) !== id) {
-      window.location.hash = id;
+    var desiredHash = encodeURIComponent(id) + (headingId ? '--' + encodeURIComponent(headingId) : '');
+    if (window.location.hash.slice(1) !== desiredHash) {
+      // replaceState avoids piling history entries when a heading is targeted
+      if (headingId) {
+        history.replaceState(null, '', location.pathname + location.search + '#' + desiredHash);
+      } else {
+        window.location.hash = id;
+      }
     }
     closeSidebar();
     setActiveNav(id);
@@ -197,7 +203,12 @@
         buildPrevNext();
         // edit-link nach prev/next aufbauen — $article.after() schiebt ihn dann zwischen article und prev/next ein
         buildEditLink();
-        window.scrollTo(0, 0);
+        if (headingId) {
+          // wait a frame so layout settles before scroll
+          requestAnimationFrame(function () { scrollToHeading(headingId); });
+        } else {
+          window.scrollTo(0, 0);
+        }
         if ($main && typeof $main.focus === 'function') {
           $main.focus({ preventScroll: true });
         }
@@ -221,20 +232,39 @@
     }
   }
 
+  function parseHash() {
+    var raw = window.location.hash.slice(1);
+    var chapterPart = raw;
+    var headingPart = '';
+    var sep = raw.indexOf('--');
+    if (sep !== -1) {
+      chapterPart = raw.slice(0, sep);
+      headingPart = raw.slice(sep + 2);
+    }
+    try { chapterPart = decodeURIComponent(chapterPart); } catch (e) { /* leave raw */ }
+    try { headingPart = decodeURIComponent(headingPart); } catch (e) { /* leave raw */ }
+    return { chapter: chapterPart, heading: headingPart };
+  }
+
   function navigateFromHash() {
-    var hash = window.location.hash.slice(1);
-    try { hash = decodeURIComponent(hash); } catch (e) { /* leave raw */ }
-    if (hash && chapters.find(function (c) { return c.id === hash; })) {
-      navigate(hash);
+    var parsed = parseHash();
+    var chapter = parsed.chapter;
+    var heading = parsed.heading;
+    if (chapter && chapters.find(function (c) { return c.id === chapter; })) {
+      navigate(chapter, heading);
     } else if (chapters.length > 0) {
       navigate(chapters[0].id);
     }
   }
 
   window.addEventListener('hashchange', function () {
-    var hash = window.location.hash.slice(1);
-    try { hash = decodeURIComponent(hash); } catch (e) { /* leave raw */ }
-    if (hash !== currentId) navigateFromHash();
+    var parsed = parseHash();
+    // chapter unchanged + heading present → just scroll, don't re-render
+    if (parsed.chapter === currentId) {
+      if (parsed.heading) scrollToHeading(parsed.heading);
+      return;
+    }
+    navigateFromHash();
   });
 
   function renderMarkdown(md) {
@@ -272,11 +302,44 @@
       btn.textContent = 'Copy';
       pre.appendChild(btn);
     });
+
+    // anchor links for h2/h3 — inserted as first child, hidden until hover (see help.css)
+    var anchorable = $article.querySelectorAll('h2, h3');
+    anchorable.forEach(function (h) {
+      var a = document.createElement('a');
+      a.className = 'help-heading-anchor';
+      a.href = '#' + encodeURIComponent(currentId) + '--' + encodeURIComponent(h.id);
+      a.setAttribute('aria-label', 'Link zu diesem Abschnitt kopieren');
+      a.dataset.headingAnchor = h.id;
+      a.textContent = '#';
+      h.insertBefore(a, h.firstChild);
+    });
   }
 
   function initArticleDelegation() {
     if (!$article) return;
     $article.addEventListener('click', function (e) {
+      var anchor = e.target.closest('.help-heading-anchor');
+      if (anchor && $article.contains(anchor)) {
+        e.preventDefault();
+        var headingId = anchor.dataset.headingAnchor;
+        if (!headingId || !currentId) return;
+        var hash = '#' + encodeURIComponent(currentId) + '--' + encodeURIComponent(headingId);
+        var url = location.origin + location.pathname + location.search + hash;
+        // replaceState so hash change doesn't pile up in history and skip the hashchange handler
+        history.replaceState(null, '', url);
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(url).then(function () {
+            showToast('Link kopiert');
+          }).catch(function () {
+            showToast('Link kopiert');
+          });
+        } else {
+          showToast('Link kopiert');
+        }
+        return;
+      }
+
       var btn = e.target.closest('.help-copy-btn');
       if (!btn || !$article.contains(btn)) return;
       var pre = btn.closest('pre');
@@ -290,6 +353,29 @@
         });
       }
     });
+  }
+
+  var toastEl = null;
+  var toastTimer = null;
+  function showToast(message) {
+    if (!toastEl) {
+      toastEl = document.createElement('div');
+      toastEl.className = 'help-toast';
+      toastEl.setAttribute('role', 'status');
+      toastEl.setAttribute('aria-live', 'polite');
+      document.body.appendChild(toastEl);
+    }
+    toastEl.textContent = message;
+    // restart css fade by toggling class off and on across frames
+    toastEl.classList.remove('visible');
+    if (toastTimer) clearTimeout(toastTimer);
+    requestAnimationFrame(function () {
+      requestAnimationFrame(function () { toastEl.classList.add('visible'); });
+    });
+    toastTimer = setTimeout(function () {
+      if (toastEl) toastEl.classList.remove('visible');
+      toastTimer = null;
+    }, 1200);
   }
 
   var tocObserver = null;


### PR DESCRIPTION
Hovering an H2/H3 reveals a subtle `#` icon. Click copies the section URL (`origin+path#chapter--heading`), updates the URL bar via `history.replaceState`, and shows a 1.2s "Link kopiert" toast. Touch / coarse-pointer devices: always visible.

**Files:** `help/help.js`, `help/help.css`, `CHANGELOG.md`.

## Test plan
- [ ] Hover H2 / H3 on desktop -> # appears
- [ ] Click -> clipboard contains URL, toast appears, URL bar updates
- [ ] Coarse-pointer: # always visible
- [ ] Hash navigation on load scrolls to the heading