### PR TITLE
docs: document image-embedding convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configurable "Edit this page on GitHub" link via `editUrl` in `chapters.json`
 - Heading anchor links: hover H2/H3 to reveal a # icon that copies the section URL.
 
+### Documentation
+- Documented image-embedding convention (Markdown syntax, suggested folder layout, sanitizer behavior).
+
 ## [2.4.0] - 2026-04-20
 
 Install/update ergonomics: one-shot update command, automatic rollback snapshot. No breaking changes — existing installs keep working unchanged until they update once.

--- a/README.md
+++ b/README.md
@@ -162,6 +162,34 @@ Everything is configured in `chapters.json`:
 
 Chapters can be nested one level deep. Parent chapters can optionally have their own `file`.
 
+## Embedding Images
+
+Images work the same way they do in regular Markdown — drop a file somewhere reachable by the static server and reference it from your chapter:
+
+```markdown
+![Sidebar in dark mode](images/sidebar-dark.png)
+```
+
+If you need more control over sizing, fall back to a raw `<img>` tag:
+
+```html
+<img src="images/sidebar-dark.png" alt="Sidebar in dark mode" width="600">
+```
+
+The suggested layout is a per-chapters `images/` folder, referenced relative to the chapter file:
+
+```
+help/
+  chapters/
+    01-getting-started.md
+    images/
+      sidebar-dark.png
+```
+
+External URLs (`https://...`) work too, as long as the host allows hot-linking and your CSP permits the image source.
+
+**A note on sanitization:** Markdown is rendered through `marked` and then scrubbed by DOMPurify. For `<img>` only a small set of attributes survives — `src`, `alt`, `title`, `width`, `height`. Event handlers (`onerror`, `onload`, ...) and anything else get stripped. That's intentional, not a bug: it's what keeps user-supplied Markdown safe to render.
+
 ## Theming
 
 Override CSS variables in `help.css` for deeper customization:

--- a/help/chapters/01-getting-started.md
+++ b/help/chapters/01-getting-started.md
@@ -67,6 +67,38 @@ Your `chapters.json` and everything under `chapters/` is **never touched**. Befo
 
 > **Tip:** Use `Ctrl+K` / `Cmd+K` to quickly search across all chapters.
 
+## Adding Images
+
+Images use standard Markdown syntax — no special setup required:
+
+```markdown
+![A friendly placeholder](images/placeholder.svg)
+```
+
+Renders as:
+
+![A friendly placeholder](images/placeholder.svg)
+
+The suggested layout is an `images/` folder right next to your chapter files:
+
+```
+help/
+  chapters/
+    01-getting-started.md
+    images/
+      placeholder.svg
+```
+
+Paths are resolved relative to the chapter file, so the example above looks up `help/chapters/images/placeholder.svg`. External URLs (`https://...`) work too.
+
+If you need more control — sizing, alignment via wrapper, etc. — drop in a raw `<img>` tag:
+
+```html
+<img src="images/placeholder.svg" alt="Placeholder" width="200">
+```
+
+DOMPurify sanitizes every rendered chapter, so only safe attributes survive on `<img>`: `src`, `alt`, `title`, `width`, `height`. Event handlers like `onerror` and unknown attributes get stripped — that's a feature, not a bug.
+
 ## Requirements
 
 - A modern browser (Chrome, Firefox, Safari, Edge)

--- a/help/chapters/images/placeholder.svg
+++ b/help/chapters/images/placeholder.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 80" width="200" height="80" role="img" aria-label="Placeholder image">
+  <rect width="200" height="80" rx="8" fill="#e8791d" opacity="0.12"/>
+  <rect x="0.5" y="0.5" width="199" height="79" rx="8" fill="none" stroke="#e8791d" stroke-opacity="0.4"/>
+  <text x="100" y="46" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" fill="#e8791d">placeholder image</text>
+</svg>


### PR DESCRIPTION
Explains how to embed images in Help Book chapters: Markdown syntax, raw `<img>` allowed attrs (DOMPurify allowlist), suggested `help/chapters/images/` layout, sanitizer caveats.

**Files:** `README.md`, `help/chapters/01-getting-started.md`, `help/chapters/images/.gitkeep` (+ placeholder SVG), `CHANGELOG.md` (Documentation).