### PR TITLE
feat: Mermaid diagram support (lazy-loaded)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Configurable "Edit this page on GitHub" link via `editUrl` in `chapters.json`
 - Heading anchor links: hover H2/H3 to reveal a # icon that copies the section URL.
+- Mermaid diagram support: ```` ```mermaid ```` code blocks render as SVG diagrams (lazy-loaded from CDN). Chapters without diagrams pay nothing. Theme tracks the help-book light/dark toggle.
+
+### Changed
+- CSP: `script-src` and `connect-src` now include `https://cdn.jsdelivr.net`; `worker-src 'self' blob:` added for mermaid's optional layout workers. Production deployments serving an HTTP CSP header must mirror these.
 
 ### Documentation
 - Documented image-embedding convention (Markdown syntax, suggested folder layout, sanitizer behavior).

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Copy the `help/` folder into your project, edit `chapters.json`, write markdown 
 - Warm orange accent (`#e8791d`) — overridable per-project via `chapters.json`
 - Pill-shaped search and copy buttons; subtle 5%-opacity borders
 - Syntax highlighting (highlight.js) with copy-to-clipboard
+- Mermaid diagram support — ```` ```mermaid ```` code blocks render as SVG (lazy-loaded from CDN, theme-aware)
 - Previous / next chapter navigation
 - Mobile responsive with safe-area insets (iPhone notch aware)
 - Accessible: skip-link, ARIA combobox search, keyboard navigation, `prefers-reduced-motion`

--- a/help/chapters/01-getting-started.md
+++ b/help/chapters/01-getting-started.md
@@ -99,6 +99,18 @@ If you need more control — sizing, alignment via wrapper, etc. — drop in a r
 
 DOMPurify sanitizes every rendered chapter, so only safe attributes survive on `<img>`: `src`, `alt`, `title`, `width`, `height`. Event handlers like `onerror` and unknown attributes get stripped — that's a feature, not a bug.
 
+## Diagrams
+
+You can embed [Mermaid](https://mermaid.js.org/) diagrams with a fenced code block tagged `mermaid`. The library is lazy-loaded from a CDN — chapters without diagrams never pay the cost.
+
+```mermaid
+graph TD
+  A[chapters.json] --> B[help.js]
+  B --> C[Markdown]
+  C --> D[Rendered Page]
+  C --> E[Search Index]
+```
+
 ## Requirements
 
 - A modern browser (Chrome, Firefox, Safari, Edge)

--- a/help/help.css
+++ b/help/help.css
@@ -1020,3 +1020,40 @@ body {
   .help-content { padding: 0; max-width: none; }
   .help-copy-btn { display: none; }
 }
+
+/* mermaid diagrams — centered card, theme-tinted background */
+.help-article .mermaid {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: var(--help-card-bg);
+  border: 1px solid var(--help-border);
+  border-radius: var(--help-radius-lg);
+  padding: 24px 16px;
+  margin: 16px 0;
+  overflow-x: auto;
+  min-height: 80px;
+  color: var(--help-text-body);
+}
+
+.help-article .mermaid svg {
+  max-width: 100%;
+  height: auto;
+}
+
+/* hide pre-render text while mermaid bootstraps so the raw source doesn't flash */
+.help-article .mermaid:not([data-processed="true"]) {
+  color: transparent;
+  user-select: none;
+}
+
+.help-article .help-mermaid-error {
+  color: #b3261e;
+  font-family: var(--help-font-mono);
+  font-size: 13px;
+  margin-bottom: 8px;
+}
+
+[data-theme="dark"] .help-article .help-mermaid-error {
+  color: #f2b8b5;
+}

--- a/help/help.js
+++ b/help/help.js
@@ -293,6 +293,9 @@
       usedIds[h.id] = true;
     });
 
+    // extract mermaid code blocks before copy buttons attach — diagram doesn't need a copy btn
+    processMermaidBlocks();
+
     // click handler is delegated on $article, see initArticleDelegation
     var pres = $article.querySelectorAll('pre');
     pres.forEach(function (pre) {
@@ -314,6 +317,107 @@
       a.textContent = '#';
       h.insertBefore(a, h.firstChild);
     });
+  }
+
+  // mermaid integration — lazy-loaded from CDN only when needed
+  var mermaidPromise = null;
+  var mermaidCounter = 0;
+
+  function currentMermaidTheme() {
+    return document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'default';
+  }
+
+  function loadMermaid() {
+    if (mermaidPromise) return mermaidPromise;
+    mermaidPromise = import('https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs')
+      .then(function (mod) {
+        var mermaid = mod.default;
+        mermaid.initialize({
+          startOnLoad: false,
+          theme: currentMermaidTheme(),
+          securityLevel: 'strict',
+          fontFamily: 'inherit',
+        });
+        return mermaid;
+      })
+      .catch(function (err) {
+        // null the cache so later chapters can retry
+        mermaidPromise = null;
+        throw err;
+      });
+    return mermaidPromise;
+  }
+
+  function processMermaidBlocks() {
+    // hljs may add its own class — match both plain and highlighted variants
+    var codes = $article.querySelectorAll('pre > code.language-mermaid, pre > code.hljs.language-mermaid');
+    if (!codes.length) return;
+
+    var sources = [];
+    codes.forEach(function (code) {
+      var pre = code.parentElement;
+      // textContent strips any hljs spans, recovers the original mermaid source
+      var src = code.textContent;
+      var div = document.createElement('div');
+      div.className = 'mermaid';
+      div.dataset.mermaidId = 'mermaid-' + (++mermaidCounter);
+      div.dataset.mermaidSource = src;
+      div.textContent = src;
+      pre.replaceWith(div);
+      sources.push({ el: div, src: src });
+    });
+
+    loadMermaid()
+      .then(function (mermaid) {
+        return mermaid.run({ querySelector: '.mermaid' });
+      })
+      .catch(function (err) {
+        sources.forEach(function (s) {
+          if (!s.el.querySelector('svg')) renderMermaidFallback(s.el, s.src, err);
+        });
+      });
+  }
+
+  function renderMermaidFallback(el, src, err) {
+    var note = document.createElement('div');
+    note.className = 'help-mermaid-error';
+    note.textContent = 'Diagram failed to render: ' + (err && err.message ? err.message : 'unknown error');
+    var pre = document.createElement('pre');
+    var code = document.createElement('code');
+    code.className = 'language-mermaid';
+    code.textContent = src;
+    pre.appendChild(code);
+    el.innerHTML = '';
+    el.appendChild(note);
+    el.appendChild(pre);
+  }
+
+  function reRenderMermaid() {
+    if (!mermaidPromise) return;
+    var nodes = $article.querySelectorAll('.mermaid');
+    if (!nodes.length) return;
+    var sources = [];
+    nodes.forEach(function (el) {
+      var src = el.dataset.mermaidSource || el.textContent;
+      el.dataset.mermaidSource = src;
+      el.removeAttribute('data-processed');
+      el.innerHTML = '';
+      el.textContent = src;
+      sources.push({ el: el, src: src });
+    });
+    mermaidPromise
+      .then(function (mermaid) {
+        mermaid.initialize({
+          startOnLoad: false,
+          theme: currentMermaidTheme(),
+          securityLevel: 'strict',
+          fontFamily: 'inherit',
+        });
+        return mermaid.run({ querySelector: '.mermaid' });
+      })
+      .catch(function (err) {
+        sources.forEach(function (s) { renderMermaidFallback(s.el, s.src, err); });
+      });
   }
 
   function initArticleDelegation() {
@@ -671,6 +775,8 @@
     }
     setHljsTheme(dark);
     if ($theme) $theme.setAttribute('aria-pressed', dark ? 'true' : 'false');
+    // re-render any mermaid diagrams with the new theme — no-op if mermaid never loaded
+    reRenderMermaid();
   }
 
   function initTheme() {

--- a/help/help.js
+++ b/help/help.js
@@ -321,7 +321,6 @@
 
   // mermaid integration — lazy-loaded from CDN only when needed
   var mermaidPromise = null;
-  var mermaidCounter = 0;
 
   function currentMermaidTheme() {
     return document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'default';
@@ -360,7 +359,6 @@
       var src = code.textContent;
       var div = document.createElement('div');
       div.className = 'mermaid';
-      div.dataset.mermaidId = 'mermaid-' + (++mermaidCounter);
       div.dataset.mermaidSource = src;
       div.textContent = src;
       pre.replaceWith(div);

--- a/help/index.html
+++ b/help/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' https://cdnjs.cloudflare.com 'unsafe-inline'; style-src 'self' https://cdnjs.cloudflare.com https://fonts.googleapis.com 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; font-src 'self' data: https://fonts.gstatic.com; base-uri 'none'; form-action 'none'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net 'unsafe-inline'; style-src 'self' https://cdnjs.cloudflare.com https://fonts.googleapis.com 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://cdn.jsdelivr.net; font-src 'self' data: https://fonts.gstatic.com; worker-src 'self' blob:; base-uri 'none'; form-action 'none'">
   <meta name="color-scheme" content="light dark">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Help</title>


### PR DESCRIPTION
` `mermaid` ` fenced blocks render as SVG diagrams via Mermaid v11 (lazy-loaded from cdn.jsdelivr.net only when a chapter contains a diagram). Theme-aware re-render on light/dark toggle, graceful error fallback.

**CSP impact:** added `cdn.jsdelivr.net` to `script-src` + `connect-src` and `worker-src 'self' blob:`. Downstream operators serving an HTTP CSP header must mirror this - flagged in CHANGELOG.

**Bundle:** Mermaid ESM ~1MB minified, lazy-loaded.

## Test plan
- [ ] Chapter with mermaid block -> renders SVG
- [ ] Chapter without -> mermaid never loads (check network)
- [ ] Toggle theme -> diagram re-renders with new theme
- [ ] Bad syntax -> error fallback shown