### PR TITLE
feat: Chart.js support (lazy-loaded)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configurable "Edit this page on GitHub" link via `editUrl` in `chapters.json`
 - Heading anchor links: hover H2/H3 to reveal a # icon that copies the section URL.
 - Mermaid diagram support: ```` ```mermaid ```` code blocks render as SVG diagrams (lazy-loaded from CDN). Chapters without diagrams pay nothing. Theme tracks the help-book light/dark toggle.
+- Chart.js support: ```` ```chart ```` code blocks with JSON config render as interactive charts (lazy-loaded). Library is fetched from `cdn.jsdelivr.net` on demand — pages without a chart pay no cost. Charts re-render on theme toggle so axis/grid colors match. JSON parse and chart-init errors fall back to the original source plus an error banner.
 
 ### Changed
 - CSP: `script-src` and `connect-src` now include `https://cdn.jsdelivr.net`; `worker-src 'self' blob:` added for mermaid's optional layout workers. Production deployments serving an HTTP CSP header must mirror these.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Copy the `help/` folder into your project, edit `chapters.json`, write markdown 
 - Pill-shaped search and copy buttons; subtle 5%-opacity borders
 - Syntax highlighting (highlight.js) with copy-to-clipboard
 - Mermaid diagram support — ```` ```mermaid ```` code blocks render as SVG (lazy-loaded from CDN, theme-aware)
+- Chart.js support: ```` ```chart ```` code blocks with JSON config render as interactive charts (lazy-loaded from CDN, only when a chart appears on the page)
 - Previous / next chapter navigation
 - Mobile responsive with safe-area insets (iPhone notch aware)
 - Accessible: skip-link, ARIA combobox search, keyboard navigation, `prefers-reduced-motion`
@@ -222,7 +223,7 @@ For production deployments, set these HTTP headers via your reverse proxy:
 X-Content-Type-Options: nosniff
 X-Frame-Options: SAMEORIGIN
 Referrer-Policy: no-referrer
-Content-Security-Policy: default-src 'none'; script-src 'self' https://cdnjs.cloudflare.com 'unsafe-inline'; style-src 'self' https://cdnjs.cloudflare.com https://fonts.googleapis.com 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; font-src 'self' data: https://fonts.gstatic.com; base-uri 'none'; form-action 'none'; frame-ancestors 'self'
+Content-Security-Policy: default-src 'none'; script-src 'self' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net 'unsafe-inline'; style-src 'self' https://cdnjs.cloudflare.com https://fonts.googleapis.com 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; font-src 'self' data: https://fonts.gstatic.com; base-uri 'none'; form-action 'none'; frame-ancestors 'self'
 ```
 
 Avoid symlinks inside `help/` — static servers may follow them and leak files outside the directory.

--- a/help/chapters/01-getting-started.md
+++ b/help/chapters/01-getting-started.md
@@ -111,6 +111,26 @@ graph TD
   C --> E[Search Index]
 ```
 
+## Charts
+
+Fenced code blocks tagged `chart` render as interactive [Chart.js](https://www.chartjs.org/) charts. The library is lazy-loaded from CDN only when a chart appears on the page.
+
+```chart
+{
+  "type": "bar",
+  "data": {
+    "labels": ["Jan", "Feb", "Mar", "Apr", "May"],
+    "datasets": [{
+      "label": "Downloads",
+      "data": [120, 180, 240, 310, 420],
+      "backgroundColor": "#e8791d"
+    }]
+  }
+}
+```
+
+Pass any valid Chart.js config as JSON. Charts adapt to the active theme on toggle.
+
 ## Requirements
 
 - A modern browser (Chrome, Firefox, Safari, Edge)

--- a/help/help.css
+++ b/help/help.css
@@ -781,6 +781,32 @@ body {
   opacity: 1;
 }
 
+.help-chart {
+  position: relative;
+  height: 320px;
+  max-width: 100%;
+  margin: 24px 0;
+  padding: 16px;
+  background: var(--help-card-bg);
+  border: 1px solid var(--help-border);
+  border-radius: var(--help-radius-lg);
+}
+
+.help-chart canvas { max-width: 100%; }
+
+.help-chart-error {
+  border-color: color-mix(in srgb, var(--help-accent) 40%, var(--help-border-strong));
+}
+
+.help-chart-error-msg {
+  padding: 12px 20px;
+  font-family: var(--help-font-mono);
+  font-size: 12px;
+  color: var(--help-accent-deep);
+  background: var(--help-accent-light);
+  border-bottom: 1px solid var(--help-border);
+}
+
 .help-article table {
   width: 100%;
   border-collapse: separate;

--- a/help/help.js
+++ b/help/help.js
@@ -293,8 +293,9 @@
       usedIds[h.id] = true;
     });
 
-    // extract mermaid code blocks before copy buttons attach — diagram doesn't need a copy btn
+    // extract mermaid/chart code blocks before copy buttons attach — they don't need copy btns
     processMermaidBlocks();
+    processChartBlocks();
 
     // click handler is delegated on $article, see initArticleDelegation
     var pres = $article.querySelectorAll('pre');
@@ -416,6 +417,119 @@
       .catch(function (err) {
         sources.forEach(function (s) { renderMermaidFallback(s.el, s.src, err); });
       });
+  }
+
+  // chart.js integration — lazy-loaded, theme-aware
+  var chartInstances = [];
+  var chartLoaderPromise = null;
+  var CHART_CDN = 'https://cdn.jsdelivr.net/npm/chart.js@4';
+
+  function loadChartLib() {
+    if (window.Chart) return Promise.resolve(window.Chart);
+    if (chartLoaderPromise) return chartLoaderPromise;
+    chartLoaderPromise = new Promise(function (resolve, reject) {
+      var s = document.createElement('script');
+      s.src = CHART_CDN;
+      s.async = true;
+      s.crossOrigin = 'anonymous';
+      s.referrerPolicy = 'no-referrer';
+      s.onload = function () {
+        if (window.Chart) resolve(window.Chart);
+        else reject(new Error('Chart.js loaded but global missing'));
+      };
+      s.onerror = function () { reject(new Error('Failed to load Chart.js')); };
+      document.head.appendChild(s);
+    });
+    return chartLoaderPromise;
+  }
+
+  function applyChartDefaults() {
+    if (!window.Chart) return;
+    var dark = document.documentElement.getAttribute('data-theme') === 'dark';
+    var styles = getComputedStyle(document.documentElement);
+    var textColor = styles.getPropertyValue('--help-text-body').trim() || (dark ? '#d4d4d4' : '#333');
+    var gridColor = dark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)';
+    var borderColor = dark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.08)';
+    window.Chart.defaults.color = textColor;
+    window.Chart.defaults.borderColor = borderColor;
+    if (window.Chart.defaults.scale && window.Chart.defaults.scale.grid) {
+      window.Chart.defaults.scale.grid.color = gridColor;
+    }
+  }
+
+  function processChartBlocks() {
+    var blocks = $article.querySelectorAll('pre > code.language-chart');
+    if (!blocks.length) return;
+
+    // collect specs first, swap each <pre> for a wrapper so injected canvas bypasses sanitizer
+    var jobs = [];
+    blocks.forEach(function (code) {
+      var pre = code.parentElement;
+      if (!pre) return;
+      var source = code.textContent;
+      var wrapper = document.createElement('div');
+      wrapper.className = 'help-chart';
+      var canvas = document.createElement('canvas');
+      wrapper.appendChild(canvas);
+      pre.replaceWith(wrapper);
+      jobs.push({ wrapper: wrapper, canvas: canvas, source: source });
+    });
+
+    loadChartLib()
+      .then(function () {
+        applyChartDefaults();
+        jobs.forEach(function (job) { renderChart(job); });
+      })
+      .catch(function (err) {
+        jobs.forEach(function (job) { renderChartError(job, err.message); });
+      });
+  }
+
+  function renderChart(job) {
+    var config;
+    try {
+      config = JSON.parse(job.source);
+    } catch (e) {
+      renderChartError(job, 'invalid JSON: ' + e.message);
+      return;
+    }
+    config.options = config.options || {};
+    if (config.options.responsive === undefined) config.options.responsive = true;
+    if (config.options.maintainAspectRatio === undefined) config.options.maintainAspectRatio = false;
+    try {
+      var inst = new window.Chart(job.canvas, config);
+      chartInstances.push({ instance: inst, source: job.source, wrapper: job.wrapper });
+    } catch (e) {
+      renderChartError(job, 'chart init failed: ' + e.message);
+    }
+  }
+
+  function renderChartError(job, msg) {
+    var pre = document.createElement('pre');
+    pre.className = 'help-chart-error';
+    var err = document.createElement('div');
+    err.className = 'help-chart-error-msg';
+    err.textContent = 'Chart error: ' + msg;
+    var code = document.createElement('code');
+    code.textContent = job.source;
+    pre.appendChild(err);
+    pre.appendChild(code);
+    job.wrapper.replaceWith(pre);
+  }
+
+  function refreshChartsForTheme() {
+    if (!window.Chart || !chartInstances.length) return;
+    applyChartDefaults();
+    // destroy + recreate so axes/grid pick up new colors
+    var snapshot = chartInstances.slice();
+    chartInstances = [];
+    snapshot.forEach(function (rec) {
+      try { rec.instance.destroy(); } catch (e) { /* ignore */ }
+      var canvas = document.createElement('canvas');
+      rec.wrapper.innerHTML = '';
+      rec.wrapper.appendChild(canvas);
+      renderChart({ wrapper: rec.wrapper, canvas: canvas, source: rec.source });
+    });
   }
 
   function initArticleDelegation() {
@@ -773,8 +887,9 @@
     }
     setHljsTheme(dark);
     if ($theme) $theme.setAttribute('aria-pressed', dark ? 'true' : 'false');
-    // re-render any mermaid diagrams with the new theme — no-op if mermaid never loaded
+    // re-render mermaid/chart with new theme — no-ops if those libs never loaded
     reRenderMermaid();
+    refreshChartsForTheme();
   }
 
   function initTheme() {

--- a/help/help.js
+++ b/help/help.js
@@ -461,7 +461,7 @@
     var blocks = $article.querySelectorAll('pre > code.language-chart');
     if (!blocks.length) return;
 
-    // collect specs first, swap each <pre> for a wrapper so injected canvas bypasses sanitizer
+    // collect specs first so the loadChartLib promise can fan out across all wrappers
     var jobs = [];
     blocks.forEach(function (code) {
       var pre = code.parentElement;


### PR DESCRIPTION
` `chart` ` fenced blocks with JSON config render as interactive Chart.js v4 canvases (lazy-loaded from cdn.jsdelivr.net). Theme-aware defaults; canvas injected post-sanitize. JSON/init errors fall back to source + error message.

**CSP impact:** `script-src` now allows `cdn.jsdelivr.net`. Downstream operators with HTTP CSP headers must mirror.

**Caveats:** Chart.js pinned to `@4` major (auto-tracks latest 4.x). No SRI - pinning a specific version would harden this further.

## Test plan
- [ ] Chart code block with valid JSON -> chart renders
- [ ] Toggle theme -> chart recreated with theme-aware colors
- [ ] Invalid JSON -> error fallback