### PR TITLE
chore: add PR template + issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,54 @@
+name: Bug report
+description: Something is broken or behaving incorrectly.
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Short summary of the bug.
+      placeholder: Search results disappear after pressing Enter.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps that trigger the bug.
+      placeholder: |
+        1. Open index.html
+        2. Press Ctrl+K
+        3. Type "foo"
+        4. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected-actual
+    attributes:
+      label: Expected vs actual
+      description: What should happen vs what actually happens.
+      placeholder: |
+        Expected: results stay visible.
+        Actual: results vanish on Enter.
+  - type: input
+    id: version
+    attributes:
+      label: help-book version
+      description: See the footer in the rendered page or the `version` in `chapters.json`.
+      placeholder: v2.4.0
+  - type: input
+    id: browser
+    attributes:
+      label: Browser + version
+      placeholder: Firefox 128, Chrome 131, Safari 17.5
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Drop images here if relevant.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else worth knowing.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,30 @@
+name: Feature request
+description: Suggest a new capability or improvement.
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem this solves
+      description: What hurts today? Who feels it?
+      placeholder: Long chapters have no way to jump back to the top on mobile.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What should happen instead.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you weighed and why they fell short.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Mockups, links, prior art.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+## Summary
+
+<!-- What changes and why, in 1-3 lines. -->
+
+## Changes
+
+-
+-
+
+## Testing
+
+<!-- How you verified this works. No build step — open index.html, reload, click around. -->
+
+-
+
+## Screenshots
+
+<!-- Optional. Required for UI changes. Light + dark, desktop + mobile if relevant. -->
+
+## Checklist
+
+- [ ] Read the contributing guidelines if any
+- [ ] Updated CHANGELOG.md
+- [ ] Tested in light and dark mode
+- [ ] Tested on mobile viewport

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Heading anchor links: hover H2/H3 to reveal a # icon that copies the section URL.
 - Mermaid diagram support: ```` ```mermaid ```` code blocks render as SVG diagrams (lazy-loaded from CDN). Chapters without diagrams pay nothing. Theme tracks the help-book light/dark toggle.
 - Chart.js support: ```` ```chart ```` code blocks with JSON config render as interactive charts (lazy-loaded). Library is fetched from `cdn.jsdelivr.net` on demand — pages without a chart pay no cost. Charts re-render on theme toggle so axis/grid colors match. JSON parse and chart-init errors fall back to the original source plus an error banner.
+- PR template and issue forms (bug report, feature request)
 
 ### Changed
 - CSP: `script-src` and `connect-src` now include `https://cdn.jsdelivr.net`; `worker-src 'self' blob:` added for mermaid's optional layout workers. Production deployments serving an HTTP CSP header must mirror these.


### PR DESCRIPTION
Standard GitHub repo templates:
- `.github/PULL_REQUEST_TEMPLATE.md` (summary / changes / testing / checklist)
- `.github/ISSUE_TEMPLATE/bug_report.yml` (issue form)
- `.github/ISSUE_TEMPLATE/feature_request.yml` (issue form)
- `.github/ISSUE_TEMPLATE/config.yml` (blank issues disabled)

YAML validated. CHANGELOG Unreleased entry added.