### PR TITLE
feat: find-in-page search with live highlights and per-match navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Search results now show a context snippet around the matched term, with the match highlighted.
+
 ## [2.4.0] - 2026-04-20
 
 Install/update ergonomics: one-shot update command, automatic rollback snapshot. No breaking changes — existing installs keep working unchanged until they update once.

--- a/help/help.css
+++ b/help/help.css
@@ -268,11 +268,14 @@ body {
 }
 
 .help-search-result-snippet {
-  font-size: 13px;
+  font-size: 12px;
+  line-height: 1.4;
   color: var(--help-text-muted);
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  word-break: break-word;
 }
 
 .help-search-result-snippet mark {
@@ -280,6 +283,7 @@ body {
   color: var(--help-accent-deep);
   border-radius: var(--help-radius-sm);
   padding: 0 2px;
+  font-weight: 500;
 }
 
 .help-search-empty {

--- a/help/help.css
+++ b/help/help.css
@@ -293,6 +293,88 @@ body {
   font-size: 14px;
 }
 
+/* find-in-page navigator: counter + prev/next at top of popup */
+.help-find-counter-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--help-border);
+  margin-bottom: 4px;
+}
+
+.help-find-counter {
+  font-size: 13px;
+  color: var(--help-text-muted);
+  font-weight: 500;
+}
+
+.help-find-nav {
+  display: inline-flex;
+  gap: 4px;
+}
+
+.help-find-nav-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 1px solid var(--help-border-strong);
+  background: var(--help-bg-secondary);
+  color: var(--help-text-body);
+  border-radius: var(--help-radius-sm);
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s, border-color 0.1s;
+}
+
+.help-find-nav-btn:hover {
+  color: var(--help-accent-deep);
+  background: var(--help-accent-light);
+  border-color: var(--help-accent);
+}
+
+.help-find-nav-btn:focus-visible {
+  outline: 2px solid var(--help-accent);
+  outline-offset: 2px;
+}
+
+.help-find-section-header {
+  padding: 8px 14px 4px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--help-text-tertiary);
+}
+
+/* in-page highlights — like browser find */
+.help-find-mark {
+  background: color-mix(in srgb, #ffec80 80%, transparent);
+  color: inherit;
+  border-radius: var(--help-radius-sm);
+  padding: 0 1px;
+}
+
+[data-theme="dark"] .help-find-mark {
+  background: color-mix(in srgb, #c9a227 55%, transparent);
+  color: #fff;
+}
+
+.help-find-mark--active {
+  background: var(--help-accent);
+  color: #fff;
+  outline: 2px solid var(--help-accent-deep);
+  outline-offset: 1px;
+}
+
+[data-theme="dark"] .help-find-mark--active {
+  background: var(--help-accent);
+  color: #fff;
+}
+
 .help-layout {
   display: block;
   min-height: calc(100dvh - var(--help-header-h));

--- a/help/help.js
+++ b/help/help.js
@@ -192,6 +192,17 @@
         buildToc();
         buildPrevNext();
         window.scrollTo(0, 0);
+        // re-apply find highlights in the freshly rendered chapter (cross-chapter jump)
+        if (lastQueryRaw && lastQueryRaw.length >= 2) {
+          applyFindHighlights(lastQueryRaw);
+          if (pendingFindAfterRender && findMarks.length) {
+            pendingFindAfterRender = false;
+            requestAnimationFrame(function () { gotoMatch(0); });
+          } else {
+            pendingFindAfterRender = false;
+          }
+          if ($results.classList.contains('active')) updateFindCounter();
+        }
         if ($main && typeof $main.focus === 'function') {
           $main.focus({ preventScroll: true });
         }
@@ -443,48 +454,191 @@
   }
 
   var searchTimeout = null;
+  // in-page find state
+  var findMarks = [];          // <mark> nodes in render order
+  var currentMatchIdx = -1;    // active index into findMarks
+  var lastQueryRaw = '';       // last query as typed (preserves case for re-apply)
+  var pendingFindAfterRender = false; // re-apply highlights after navigate() renders
+  // skip text inside these containers when wrapping matches
+  var FIND_SKIP_SELECTOR = 'mark, .help-heading-anchor, .help-copy-btn';
 
   $search.addEventListener('input', function () {
     clearTimeout(searchTimeout);
-    var raw = $search.value.trim();
+    var raw = $search.value;
     if (raw.length > 200) raw = raw.slice(0, 200);
-    var q = raw.toLocaleLowerCase('de');
+    lastQueryRaw = raw.trim();
+    var q = lastQueryRaw.toLocaleLowerCase('de');
     if (q.length < 2) {
+      clearFindHighlights();
       $results.classList.remove('active');
       $results.innerHTML = '';
       return;
     }
     if (!chaptersReady) {
+      clearFindHighlights();
       $results.innerHTML = '<div class="help-search-empty">Indexing…</div>';
       $results.classList.add('active');
       return;
     }
+    // immediate in-page highlight feels responsive, cross-chapter list can debounce
+    applyFindHighlights(lastQueryRaw);
     searchTimeout = setTimeout(function () { performSearch(q); }, 150);
   });
 
   $search.addEventListener('keydown', function (e) {
     if (e.key === 'Escape') {
-      $search.value = '';
-      $results.classList.remove('active');
+      closeFind();
       $search.blur();
+      return;
+    }
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      if (!findMarks.length) return;
+      if (e.shiftKey) gotoMatch(currentMatchIdx - 1);
+      else gotoMatch(currentMatchIdx + 1);
     }
   });
 
   document.addEventListener('click', function (e) {
-    if (!e.target.closest('.help-search-wrapper')) {
-      $results.classList.remove('active');
-    }
+    if (e.target.closest('.help-search-wrapper')) return;
+    if (e.target.closest('.help-find-mark')) return;
+    // click outside: close popup AND clear highlights (per spec)
+    closeFind();
   });
 
   $results.addEventListener('click', function (e) {
+    // nav buttons inside the "auf dieser seite" counter
+    var navBtn = e.target.closest('[data-find-nav]');
+    if (navBtn) {
+      e.preventDefault();
+      if (!findMarks.length) return;
+      if (navBtn.dataset.findNav === 'prev') gotoMatch(currentMatchIdx - 1);
+      else gotoMatch(currentMatchIdx + 1);
+      return;
+    }
+
     var result = e.target.closest('.help-search-result');
     if (!result) return;
     e.preventDefault();
     var id = result.getAttribute('href').slice(1);
-    $search.value = '';
-    $results.classList.remove('active');
-    navigate(id);
+    // keep the query, re-apply highlights after the new chapter renders
+    if (id !== currentId) {
+      pendingFindAfterRender = true;
+      navigate(id);
+    } else {
+      // already here — just jump to first match
+      if (findMarks.length) gotoMatch(0);
+    }
   });
+
+  function closeFind() {
+    $search.value = '';
+    lastQueryRaw = '';
+    pendingFindAfterRender = false;
+    $results.classList.remove('active');
+    $results.innerHTML = '';
+    clearFindHighlights();
+  }
+
+  // walk text nodes inside $article and wrap matches of query (case-insensitive)
+  // in <mark class="help-find-mark">. skips pre/code/anchor blocks.
+  function applyFindHighlights(rawQuery) {
+    clearFindHighlights();
+    if (!rawQuery || rawQuery.length < 2 || !$article) return;
+    var qLower = rawQuery.toLocaleLowerCase('de');
+    var qLen = rawQuery.length;
+
+    var walker = document.createTreeWalker($article, NodeFilter.SHOW_TEXT, {
+      acceptNode: function (node) {
+        if (!node.nodeValue) return NodeFilter.FILTER_REJECT;
+        var p = node.parentNode;
+        while (p && p !== $article) {
+          if (p.nodeType === 1 && p.matches && p.matches(FIND_SKIP_SELECTOR)) {
+            return NodeFilter.FILTER_REJECT;
+          }
+          p = p.parentNode;
+        }
+        // cheap reject: only wrap if the text actually contains the query
+        if (node.nodeValue.toLocaleLowerCase('de').indexOf(qLower) === -1) {
+          return NodeFilter.FILTER_REJECT;
+        }
+        return NodeFilter.FILTER_ACCEPT;
+      }
+    });
+
+    var hits = [];
+    var n;
+    while ((n = walker.nextNode())) hits.push(n);
+
+    hits.forEach(function (textNode) {
+      var text = textNode.nodeValue;
+      var lower = text.toLocaleLowerCase('de');
+      var frag = document.createDocumentFragment();
+      var last = 0;
+      var idx = lower.indexOf(qLower);
+      while (idx !== -1) {
+        if (idx > last) frag.appendChild(document.createTextNode(text.slice(last, idx)));
+        var mark = document.createElement('mark');
+        mark.className = 'help-find-mark';
+        // preserve original casing from the source text
+        mark.textContent = text.slice(idx, idx + qLen);
+        frag.appendChild(mark);
+        findMarks.push(mark);
+        last = idx + qLen;
+        idx = lower.indexOf(qLower, last);
+      }
+      if (last < text.length) frag.appendChild(document.createTextNode(text.slice(last)));
+      textNode.parentNode.replaceChild(frag, textNode);
+    });
+
+    currentMatchIdx = -1;
+  }
+
+  function clearFindHighlights() {
+    if (!findMarks.length) {
+      currentMatchIdx = -1;
+      return;
+    }
+    findMarks.forEach(function (mark) {
+      var parent = mark.parentNode;
+      if (!parent) return;
+      // replace mark with its text content and merge with neighboring text nodes
+      var textNode = document.createTextNode(mark.textContent);
+      parent.replaceChild(textNode, mark);
+      parent.normalize();
+    });
+    findMarks = [];
+    currentMatchIdx = -1;
+  }
+
+  function gotoMatch(idx) {
+    if (!findMarks.length) return;
+    // wrap around
+    if (idx < 0) idx = findMarks.length - 1;
+    if (idx >= findMarks.length) idx = 0;
+    if (currentMatchIdx >= 0 && findMarks[currentMatchIdx]) {
+      findMarks[currentMatchIdx].classList.remove('help-find-mark--active');
+    }
+    currentMatchIdx = idx;
+    var el = findMarks[idx];
+    el.classList.add('help-find-mark--active');
+    try {
+      el.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    } catch (e) {
+      el.scrollIntoView();
+    }
+    updateFindCounter();
+  }
+
+  function updateFindCounter() {
+    var counter = $results.querySelector('[data-find-counter]');
+    if (!counter) return;
+    if (!findMarks.length) {
+      counter.textContent = 'Keine Treffer hier';
+    } else {
+      counter.textContent = (currentMatchIdx + 1) + ' von ' + findMarks.length + ' auf dieser Seite';
+    }
+  }
 
   // strip the most disruptive markdown syntax so snippets read like plain text.
   // not a full parser — good enough for inline preview.
@@ -544,6 +698,8 @@
     var results = [];
 
     chapters.forEach(function (ch) {
+      // hide current chapter from "andere kapitel" — user is already here
+      if (ch.id === currentId) return;
       var text = chapterTexts[ch.id] || '';
       var titleLower = (ch.title || '').toLocaleLowerCase('de');
       var bodyLower = text.toLocaleLowerCase('de');
@@ -563,12 +719,42 @@
     });
 
     $results.innerHTML = '';
-    if (results.length === 0) {
-      var empty = document.createElement('div');
-      empty.className = 'help-search-empty';
-      empty.textContent = 'No results found';
-      $results.appendChild(empty);
-    } else {
+
+    // top row: in-page counter + prev/next buttons
+    var counterRow = document.createElement('div');
+    counterRow.className = 'help-find-counter-row';
+    var counter = document.createElement('span');
+    counter.className = 'help-find-counter';
+    counter.setAttribute('data-find-counter', '');
+    counterRow.appendChild(counter);
+
+    var navWrap = document.createElement('span');
+    navWrap.className = 'help-find-nav';
+    var prevBtn = document.createElement('button');
+    prevBtn.type = 'button';
+    prevBtn.className = 'help-find-nav-btn';
+    prevBtn.dataset.findNav = 'prev';
+    prevBtn.setAttribute('aria-label', 'Vorheriger Treffer');
+    prevBtn.innerHTML = '<svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3,8 6,4 9,8"/></svg>';
+    var nextBtn = document.createElement('button');
+    nextBtn.type = 'button';
+    nextBtn.className = 'help-find-nav-btn';
+    nextBtn.dataset.findNav = 'next';
+    nextBtn.setAttribute('aria-label', 'Naechster Treffer');
+    nextBtn.innerHTML = '<svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3,4 6,8 9,4"/></svg>';
+    navWrap.appendChild(prevBtn);
+    navWrap.appendChild(nextBtn);
+    counterRow.appendChild(navWrap);
+    $results.appendChild(counterRow);
+    updateFindCounter();
+
+    // "andere kapitel" section
+    if (results.length > 0) {
+      var header = document.createElement('div');
+      header.className = 'help-find-section-header';
+      header.textContent = 'Andere Kapitel';
+      $results.appendChild(header);
+
       results.slice(0, 10).forEach(function (r) {
         var a = document.createElement('a');
         a.className = 'help-search-result';
@@ -590,6 +776,12 @@
 
         $results.appendChild(a);
       });
+    } else if (!findMarks.length) {
+      // nothing here, nothing elsewhere
+      var empty = document.createElement('div');
+      empty.className = 'help-search-empty';
+      empty.textContent = 'Keine Ergebnisse';
+      $results.appendChild(empty);
     }
 
     $results.classList.add('active');

--- a/help/help.js
+++ b/help/help.js
@@ -486,37 +486,110 @@
     navigate(id);
   });
 
+  // strip the most disruptive markdown syntax so snippets read like plain text.
+  // not a full parser — good enough for inline preview.
+  function stripMarkdown(text) {
+    return text
+      .replace(/```[\s\S]*?```/g, ' ')           // fenced code blocks
+      .replace(/`([^`]+)`/g, '$1')               // inline code
+      .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')  // images → alt text
+      .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')   // links → label
+      .replace(/^#{1,6}\s+/gm, '')               // heading markers
+      .replace(/(\*\*|__)(.*?)\1/g, '$2')        // bold
+      .replace(/(\*|_)(.*?)\1/g, '$2')           // italic
+      .replace(/^\s*>\s?/gm, '')                 // blockquote
+      .replace(/^\s*[-*+]\s+/gm, '')             // unordered list bullet
+      .replace(/\s+/g, ' ')                      // collapse whitespace
+      .trim();
+  }
+
+  function buildSnippet(text, query) {
+    var clean = stripMarkdown(text);
+    if (!clean) return null;
+    var lower = clean.toLocaleLowerCase('de');
+    var idx = lower.indexOf(query);
+    if (idx === -1) return null;
+    // ~120 chars centered on the match
+    var pad = Math.max(0, Math.floor((120 - query.length) / 2));
+    var start = Math.max(0, idx - pad);
+    var end = Math.min(clean.length, idx + query.length + pad);
+    return {
+      before: (start > 0 ? '…' : '') + clean.substring(start, idx),
+      match:  clean.substring(idx, idx + query.length),
+      after:  clean.substring(idx + query.length, end) + (end < clean.length ? '…' : '')
+    };
+  }
+
+  function buildPreview(text) {
+    var clean = stripMarkdown(text);
+    if (!clean) return '';
+    if (clean.length <= 120) return clean;
+    return clean.substring(0, 120) + '…';
+  }
+
+  // build the snippet element using text nodes + <mark>, so chapter content
+  // never reaches the DOM as raw html.
+  function renderSnippet(container, parts) {
+    if (parts) {
+      container.appendChild(document.createTextNode(parts.before));
+      var mark = document.createElement('mark');
+      mark.textContent = parts.match;
+      container.appendChild(mark);
+      container.appendChild(document.createTextNode(parts.after));
+    }
+  }
+
   function performSearch(query) {
     if (!chaptersReady) return;
     var results = [];
 
     chapters.forEach(function (ch) {
       var text = chapterTexts[ch.id] || '';
-      var lower = text.toLocaleLowerCase('de');
-      var idx = lower.indexOf(query);
-      if (idx === -1) return;
+      var titleLower = (ch.title || '').toLocaleLowerCase('de');
+      var bodyLower = text.toLocaleLowerCase('de');
+      var titleMatch = titleLower.indexOf(query) !== -1;
+      var bodyMatch = bodyLower.indexOf(query) !== -1;
+      if (!titleMatch && !bodyMatch) return;
 
-      var start = Math.max(0, idx - 40);
-      var end = Math.min(text.length, idx + query.length + 60);
-      var snippet = (start > 0 ? '...' : '') +
-        text.substring(start, end).replace(/\n/g, ' ') +
-        (end < text.length ? '...' : '');
-
-      var escaped = escapeHtml(snippet);
-      var re = new RegExp('(' + escapeRegex(escapeHtml(query)) + ')', 'gi');
-      escaped = escaped.replace(re, '<mark>$1</mark>');
-
-      results.push({ id: ch.id, title: ch.title, snippet: escaped });
+      var entry = { id: ch.id, title: ch.title, parts: null, preview: '' };
+      if (bodyMatch) {
+        entry.parts = buildSnippet(text, query);
+      }
+      if (!entry.parts) {
+        // title-only hit or empty body — fall back to first chunk of content
+        entry.preview = buildPreview(text);
+      }
+      results.push(entry);
     });
 
+    $results.innerHTML = '';
     if (results.length === 0) {
-      $results.innerHTML = '<div class="help-search-empty">No results found</div>';
+      var empty = document.createElement('div');
+      empty.className = 'help-search-empty';
+      empty.textContent = 'No results found';
+      $results.appendChild(empty);
     } else {
-      $results.innerHTML = results.slice(0, 10).map(function (r) {
-        return '<a class="help-search-result" href="#' + encodeURIComponent(r.id) + '">' +
-          '<div class="help-search-result-title">' + escapeHtml(r.title) + '</div>' +
-          '<div class="help-search-result-snippet">' + r.snippet + '</div></a>';
-      }).join('');
+      results.slice(0, 10).forEach(function (r) {
+        var a = document.createElement('a');
+        a.className = 'help-search-result';
+        a.href = '#' + encodeURIComponent(r.id);
+
+        var title = document.createElement('div');
+        title.className = 'help-search-result-title';
+        title.textContent = r.title;
+        a.appendChild(title);
+
+        var snippet = document.createElement('div');
+        snippet.className = 'help-search-result-snippet';
+        if (r.parts) {
+          renderSnippet(snippet, r.parts);
+        } else {
+          snippet.textContent = r.preview;
+        }
+        a.appendChild(snippet);
+
+        $results.appendChild(a);
+      });
     }
 
     $results.classList.add('active');
@@ -608,10 +681,6 @@
       .replace(/</g, '&lt;')
       .replace(/>/g, '&gt;')
       .replace(/"/g, '&quot;');
-  }
-
-  function escapeRegex(str) {
-    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   }
 
 })();


### PR DESCRIPTION
Builds on top of #44 (search-snippets). New search UX:

- Typing a query wraps every occurrence in the **current chapter** with `<mark class="help-find-mark">`, live as you type.
- Counter row under the search input: **"X von Y auf dieser Seite"** with prev/next icon buttons.
- **Enter** -> next match (smooth-scroll center, `.help-find-mark--active` accent + outline on the focused match). **Shift+Enter** -> previous. Wraps around at the ends.
- **Andere Kapitel** section below the counter retains the cross-chapter results list from #44. Clicking a row navigates to that chapter and auto-applies the highlights + jumps to the first match there.
- **ESC** or click-outside closes the popup and clears highlights.
- Code blocks ARE searched (skip filter limited to existing `<mark>`, `.help-heading-anchor`, `.help-copy-btn`).

## Notes
- Highlights are injected via TextNode-walking with `parent.normalize()` on cleanup -- idempotent across re-applies.
- Current chapter is intentionally excluded from the cross-chapter list (already covered by in-page counter).
- Active mark color uses the existing accent CSS variable -- adapts to light/dark.

## Test plan
- [ ] Type query -> matches highlight live
- [ ] Enter cycles forward, Shift+Enter back, wraps at edges
- [ ] Counter updates correctly
- [ ] Click cross-chapter result -> navigates + jumps to first match in new chapter
- [ ] ESC clears highlights and closes popup
- [ ] Code block content gets highlighted too
- [ ] No double-wrap of `<mark>` on repeated keystrokes