### PR TITLE
docs: rewrite demo as feature showcase

### DIFF
--- a/help/chapters.json
+++ b/help/chapters.json
@@ -1,13 +1,49 @@
 {
   "title": "Help Book Demo",
-  "version": "v2.4.0",
+  "version": "v2.5.0-dev",
   "accent": "#e8791d",
   "editUrl": "https://github.com/leminkozey/help-book/edit/main/help/{file}",
   "chapters": [
     {
       "id": "getting-started",
-      "title": "Getting Started",
+      "title": "Welcome",
       "file": "chapters/01-getting-started.md"
+    },
+    {
+      "id": "whats-new",
+      "title": "What's New",
+      "children": [
+        {
+          "id": "images",
+          "title": "Images",
+          "file": "chapters/04-whats-new/01-images.md"
+        },
+        {
+          "id": "diagrams",
+          "title": "Diagrams (Mermaid)",
+          "file": "chapters/04-whats-new/02-diagrams.md"
+        },
+        {
+          "id": "charts",
+          "title": "Charts (Chart.js)",
+          "file": "chapters/04-whats-new/03-charts.md"
+        },
+        {
+          "id": "anchors",
+          "title": "Heading Anchors",
+          "file": "chapters/04-whats-new/04-anchor-links.md"
+        },
+        {
+          "id": "find-on-page",
+          "title": "Find on Page",
+          "file": "chapters/04-whats-new/05-find-on-page.md"
+        },
+        {
+          "id": "edit-on-github",
+          "title": "Edit on GitHub",
+          "file": "chapters/04-whats-new/06-edit-on-github.md"
+        }
+      ]
     },
     {
       "id": "configuration",
@@ -16,16 +52,16 @@
     },
     {
       "id": "features",
-      "title": "Features",
+      "title": "Markdown Reference",
       "children": [
         {
           "id": "dashboard",
-          "title": "Dashboard",
+          "title": "Formatting Showcase",
           "file": "chapters/03-features/01-dashboard.md"
         },
         {
           "id": "settings",
-          "title": "Settings",
+          "title": "Theming & Settings",
           "file": "chapters/03-features/02-settings.md"
         }
       ]

--- a/help/chapters/01-getting-started.md
+++ b/help/chapters/01-getting-started.md
@@ -1,6 +1,8 @@
-# Getting Started
+# Welcome
 
-Welcome to the Help Book — a standalone, drop-in documentation system for any web project.
+The Help Book is a standalone, drop-in documentation system for any web project. No build step, no npm, no framework — copy a folder, write Markdown, serve as static files.
+
+This demo doubles as a showcase: every chapter under **What's New** demonstrates one of the features added in the latest release.
 
 ## Installation
 
@@ -12,7 +14,7 @@ curl -fsSL https://raw.githubusercontent.com/leminkozey/help-book/main/scripts/i
 
 This drops a ready-to-edit `help/` folder in the current directory with a starter `chapters.json` plus one demo chapter.
 
-### Final layout
+## Final layout
 
 ```
 your-project/
@@ -59,80 +61,10 @@ Your `chapters.json` and everything under `chapters/` is **never touched**. Befo
 3. **help.js** loads the manifest, builds the sidebar, and renders markdown on the fly
 4. No build step, no dependencies to install — just static files
 
-## Quick Start
-
-1. Edit `chapters.json` to set your project name, version, and chapters
-2. Write your markdown files in `chapters/`
-3. Done
-
-> **Tip:** Use `Ctrl+K` / `Cmd+K` to quickly search across all chapters.
-
-## Adding Images
-
-Images use standard Markdown syntax — no special setup required:
-
-```markdown
-![A friendly placeholder](images/placeholder.svg)
-```
-
-Renders as:
-
-![A friendly placeholder](images/placeholder.svg)
-
-The suggested layout is an `images/` folder right next to your chapter files:
-
-```
-help/
-  chapters/
-    01-getting-started.md
-    images/
-      placeholder.svg
-```
-
-Paths are resolved relative to the chapter file, so the example above looks up `help/chapters/images/placeholder.svg`. External URLs (`https://...`) work too.
-
-If you need more control — sizing, alignment via wrapper, etc. — drop in a raw `<img>` tag:
-
-```html
-<img src="images/placeholder.svg" alt="Placeholder" width="200">
-```
-
-DOMPurify sanitizes every rendered chapter, so only safe attributes survive on `<img>`: `src`, `alt`, `title`, `width`, `height`. Event handlers like `onerror` and unknown attributes get stripped — that's a feature, not a bug.
-
-## Diagrams
-
-You can embed [Mermaid](https://mermaid.js.org/) diagrams with a fenced code block tagged `mermaid`. The library is lazy-loaded from a CDN — chapters without diagrams never pay the cost.
-
-```mermaid
-graph TD
-  A[chapters.json] --> B[help.js]
-  B --> C[Markdown]
-  C --> D[Rendered Page]
-  C --> E[Search Index]
-```
-
-## Charts
-
-Fenced code blocks tagged `chart` render as interactive [Chart.js](https://www.chartjs.org/) charts. The library is lazy-loaded from CDN only when a chart appears on the page.
-
-```chart
-{
-  "type": "bar",
-  "data": {
-    "labels": ["Jan", "Feb", "Mar", "Apr", "May"],
-    "datasets": [{
-      "label": "Downloads",
-      "data": [120, 180, 240, 310, 420],
-      "backgroundColor": "#e8791d"
-    }]
-  }
-}
-```
-
-Pass any valid Chart.js config as JSON. Charts adapt to the active theme on toggle.
+> **Tip:** Use `Ctrl+K` / `Cmd+K` to focus the search. Type two characters to start matching — see the **Find on Page** chapter for what happens next.
 
 ## Requirements
 
 - A modern browser (Chrome, Firefox, Safari, Edge)
 - A web server that can serve static files
-- That's it. No npm, no webpack, no build pipeline.
+- That's it.

--- a/help/chapters/04-whats-new/01-images.md
+++ b/help/chapters/04-whats-new/01-images.md
@@ -1,0 +1,41 @@
+# Images
+
+Drop a file under `chapters/images/` and reference it from any chapter with normal Markdown:
+
+```markdown
+![A friendly placeholder](images/placeholder.svg)
+```
+
+Renders as:
+
+![A friendly placeholder](images/placeholder.svg)
+
+## Sizing
+
+For inline control, fall back to a raw `<img>` tag — the sanitizer keeps `src`, `alt`, `title`, `width`, and `height`:
+
+```html
+<img src="images/placeholder.svg" alt="Small" width="120">
+<img src="images/placeholder.svg" alt="Large" width="320">
+```
+
+<img src="images/placeholder.svg" alt="Small" width="120">
+
+<img src="images/placeholder.svg" alt="Large" width="320">
+
+## Suggested layout
+
+```
+help/
+  chapters/
+    04-whats-new/
+      01-images.md
+    images/
+      placeholder.svg
+```
+
+Paths resolve relative to the chapter file. External URLs (`https://…`) work too, as long as the host allows hot-linking and the CSP permits the image source.
+
+## Sanitization
+
+Markdown runs through `marked` and is scrubbed by DOMPurify before hitting the DOM. On `<img>`, only `src`, `alt`, `title`, `width`, `height` survive — event handlers (`onerror`, `onload`) and unknown attributes are stripped. That's the safety net for user-supplied Markdown, not a missing feature.

--- a/help/chapters/04-whats-new/02-diagrams.md
+++ b/help/chapters/04-whats-new/02-diagrams.md
@@ -1,0 +1,47 @@
+# Diagrams (Mermaid)
+
+A fenced code block tagged `mermaid` renders as an SVG diagram. The library is lazy-loaded from `cdn.jsdelivr.net` — chapters without a diagram never pay the cost.
+
+## Flowchart
+
+```mermaid
+graph TD
+  A[chapters.json] --> B[help.js]
+  B --> C[Markdown]
+  C --> D[Rendered Page]
+  C --> E[Search Index]
+  D --> F((User))
+  E --> F
+```
+
+## Sequence
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant H as help.js
+  participant M as marked + DOMPurify
+  U->>H: navigate(chapterId)
+  H->>H: fetch chapter.md
+  H->>M: parse + sanitize
+  M-->>H: clean HTML
+  H-->>U: render + scroll
+```
+
+## State
+
+```mermaid
+stateDiagram-v2
+  [*] --> Idle
+  Idle --> Indexing: fetch chapters
+  Indexing --> Ready: all loaded
+  Ready --> Searching: Ctrl+K
+  Searching --> Ready: Esc
+  Ready --> [*]
+```
+
+## Theme
+
+Diagrams track the active theme. Toggle dark/light via the moon icon in the header and the SVG re-renders with the appropriate palette.
+
+> The Mermaid integration uses `securityLevel: 'strict'` — embedded JS in diagrams is disabled.

--- a/help/chapters/04-whats-new/03-charts.md
+++ b/help/chapters/04-whats-new/03-charts.md
@@ -1,0 +1,84 @@
+# Charts (Chart.js)
+
+A fenced code block tagged `chart` with a Chart.js config (as JSON) renders as an interactive chart. Chart.js is loaded from `cdn.jsdelivr.net` on demand — chapters without a chart pay no cost.
+
+## Bar
+
+```chart
+{
+  "type": "bar",
+  "data": {
+    "labels": ["Jan", "Feb", "Mar", "Apr", "May", "Jun"],
+    "datasets": [{
+      "label": "Downloads",
+      "data": [120, 180, 240, 310, 420, 510],
+      "backgroundColor": "#e8791d"
+    }]
+  }
+}
+```
+
+## Line
+
+```chart
+{
+  "type": "line",
+  "data": {
+    "labels": ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
+    "datasets": [
+      {
+        "label": "Sessions",
+        "data": [42, 51, 49, 60, 72, 35, 30],
+        "borderColor": "#e8791d",
+        "backgroundColor": "rgba(232, 121, 29, 0.2)",
+        "tension": 0.35,
+        "fill": true
+      },
+      {
+        "label": "Conversions",
+        "data": [8, 12, 11, 14, 18, 6, 5],
+        "borderColor": "#3b82f6",
+        "backgroundColor": "rgba(59, 130, 246, 0.2)",
+        "tension": 0.35,
+        "fill": true
+      }
+    ]
+  }
+}
+```
+
+## Doughnut
+
+```chart
+{
+  "type": "doughnut",
+  "data": {
+    "labels": ["Markdown", "JS", "CSS", "HTML"],
+    "datasets": [{
+      "data": [55, 25, 15, 5],
+      "backgroundColor": ["#e8791d", "#3b82f6", "#22c55e", "#a78bfa"]
+    }]
+  }
+}
+```
+
+## Radar
+
+```chart
+{
+  "type": "radar",
+  "data": {
+    "labels": ["Speed", "DX", "Security", "Customization", "Accessibility", "Footprint"],
+    "datasets": [{
+      "label": "help-book",
+      "data": [9, 8, 9, 7, 8, 10],
+      "borderColor": "#e8791d",
+      "backgroundColor": "rgba(232, 121, 29, 0.25)"
+    }]
+  }
+}
+```
+
+## How it works
+
+Pass any valid Chart.js config as JSON. Charts re-render on theme toggle so axis and grid colors match. If the JSON is invalid or `Chart` fails to initialize, the original source is shown with an error banner — readers never see a broken canvas.

--- a/help/chapters/04-whats-new/04-anchor-links.md
+++ b/help/chapters/04-whats-new/04-anchor-links.md
@@ -1,0 +1,35 @@
+# Heading Anchors
+
+Hover any H2 or H3 in this chapter and a `#` appears to the left of the heading. Click it to copy a deep link straight to that section.
+
+## How it looks
+
+Move your mouse over any of the headings below. On touch devices the anchor stays visible at low contrast.
+
+## Deep links
+
+A copied link looks like this:
+
+```
+https://yoursite.com/help/#anchors--deep-links
+```
+
+The hash uses a `chapterId--headingId` shape. Reloading the page lands you back at this exact heading after a frame of layout.
+
+## Cross-chapter jumps
+
+Anchors keep working when you paste them. Open one in a new tab and the help-book navigates to the right chapter, renders it, then scrolls to the heading once layout settles.
+
+## Mobile
+
+On narrow viewports the left gutter disappears, so the anchor renders inline before the heading text instead of in the margin. Same behavior, just less hidden.
+
+## Accessibility
+
+- `aria-label="Copy link to this section"` on every anchor
+- Focus ring on keyboard tab, copy works via Enter
+- Toast announces success or, on clipboard failure, points at the address bar
+
+## Try it
+
+Hover over **How it looks**, **Deep links**, **Cross-chapter jumps**, **Mobile**, or **Accessibility** above and click the `#`. The URL in the address bar updates without a page reload.

--- a/help/chapters/04-whats-new/05-find-on-page.md
+++ b/help/chapters/04-whats-new/05-find-on-page.md
@@ -1,0 +1,33 @@
+# Find on Page
+
+The search box pulls double duty: typing two or more characters highlights matches **on this page** inline (like browser find) and lists hits in **other chapters** below.
+
+## Try it now
+
+1. Press `Ctrl+K` or `Cmd+K` to focus search
+2. Type `lazy` and watch this chapter light up — every match wraps in a yellow `<mark>` tag
+3. Press **Enter** to jump to the next match, **Shift+Enter** to jump back
+4. The active match turns orange and smooth-scrolls into view
+5. Press **Esc** or click outside to clear
+
+## The counter
+
+A counter row sits at the top of the popup: **N of M on this page**, with prev/next buttons next to it. Useful when you want to know how many matches a long chapter has before you start cycling.
+
+## Cross-chapter results
+
+Below the counter, the popup lists chapters that contain the same term (current chapter excluded — you're already on it). Each result shows a context snippet with the match highlighted. Click one and the help-book navigates over and re-applies the highlights in the new chapter.
+
+## Skip zones
+
+Find-on-page walks the article tree but skips:
+
+- existing `<mark>` nodes (no nested highlights)
+- the `#` anchor links on headings
+- copy buttons on code blocks
+
+Everything else — paragraph text, code blocks, table cells, blockquotes — is fair game.
+
+## Some lazy filler so you have matches to cycle through
+
+The lazy fox jumps over the lazy dog. The lazy author writes lazy filler. The lazy parser would have missed this, but find-on-page is not lazy. The lazy reader scrolls past anyway.

--- a/help/chapters/04-whats-new/06-edit-on-github.md
+++ b/help/chapters/04-whats-new/06-edit-on-github.md
@@ -1,0 +1,41 @@
+# Edit on GitHub
+
+Every chapter can show a muted "Edit this page on GitHub" link at the bottom. Scroll down — there's one on this page right now (above the prev/next nav).
+
+## Setup
+
+Add a single key to `chapters.json`:
+
+```json
+{
+  "title": "My Project",
+  "editUrl": "https://github.com/you/repo/edit/main/help/{file}",
+  "chapters": [ ... ]
+}
+```
+
+The `{file}` placeholder gets replaced with the current chapter's `file` value (URL-encoded). Omit the key and the link disappears — no flag, no fallback, just absence.
+
+## What it does
+
+- One link per chapter, rendered between the article body and the prev/next nav
+- Opens in a new tab with `rel="noopener noreferrer"`
+- Small pencil icon for affordance, muted color so it doesn't compete with content
+
+## Other Git hosts
+
+The pattern is `host/edit/branch/path`. Examples:
+
+```json
+{
+  "editUrl": "https://gitlab.com/you/repo/-/edit/main/help/{file}"
+}
+```
+
+```json
+{
+  "editUrl": "https://codeberg.org/you/repo/_edit/main/help/{file}"
+}
+```
+
+Anything that resolves to an HTTPS URL is accepted (validated against `^https?://`).


### PR DESCRIPTION
The bundled demo (\`help/chapters/\`) is what users see on the live demo page and what installer drops into new projects. After the v2.5 feature blitz the demo had drifted — getting-started accreted Mermaid + Chart + image demos in passing, but nothing else surfaced anchors, find-on-page, or edit-on-github.

This rewrite gives every new feature its own chapter, so the demo doubles as documentation.

## Structure

- **Welcome** — installer + how-it-works only, no feature demos
- **What's New** (nested)
  - Images (markdown + raw img sizing)
  - Diagrams (Mermaid: flowchart, sequence, state)
  - Charts (Chart.js: bar, line, doughnut, radar)
  - Heading Anchors (deep-link demo, multiple H2/H3)
  - Find on Page (lazy filler so users have matches to cycle)
  - Edit on GitHub
- **Configuration**
- **Markdown Reference** (formatting + theming, renamed from "Features")

Bumped \`version\` in the demo \`chapters.json\` to \`v2.5.0-dev\` so it's clear this represents the in-flight release.

## Test plan
- [ ] \`python3 -m http.server 8082 --directory help\` and click every chapter
- [ ] Verify Mermaid renders all three diagram types
- [ ] Verify Chart.js renders all four chart types
- [ ] Verify theme toggle re-renders both Mermaid and Chart.js
- [ ] Verify find-on-page lights up matches in the new chapters
- [ ] Verify heading anchors copy correctly