### PR TITLE
docs: showcase SVGs for demo

### DIFF
--- a/help/chapters/01-getting-started.md
+++ b/help/chapters/01-getting-started.md
@@ -2,6 +2,8 @@
 
 The Help Book is a standalone, drop-in documentation system for any web project. No build step, no npm, no framework — copy a folder, write Markdown, serve as static files.
 
+![Help Book demo — sidebar, search, and a Chart.js block in the article](images/sidebar-mock.svg)
+
 This demo doubles as a showcase: every chapter under **What's New** demonstrates one of the features added in the latest release.
 
 ## Installation

--- a/help/chapters/04-whats-new/01-images.md
+++ b/help/chapters/04-whats-new/01-images.md
@@ -3,12 +3,19 @@
 Drop a file under `chapters/images/` and reference it from any chapter with normal Markdown:
 
 ```markdown
-![A friendly placeholder](images/placeholder.svg)
+![Help Book sidebar in light mode](images/sidebar-mock.svg)
 ```
 
 Renders as:
 
-![A friendly placeholder](images/placeholder.svg)
+![Help Book sidebar in light mode](images/sidebar-mock.svg)
+
+## Light + dark
+
+Pair shots for theme docs travel well as side-by-side `<img>` tags:
+
+<img src="images/sidebar-mock.svg" alt="Sidebar — light" width="230">
+<img src="images/sidebar-mock-dark.svg" alt="Sidebar — dark" width="230">
 
 ## Sizing
 
@@ -31,6 +38,8 @@ help/
     04-whats-new/
       01-images.md
     images/
+      sidebar-mock.svg
+      sidebar-mock-dark.svg
       placeholder.svg
 ```
 

--- a/help/chapters/04-whats-new/04-anchor-links.md
+++ b/help/chapters/04-whats-new/04-anchor-links.md
@@ -2,6 +2,8 @@
 
 Hover any H2 or H3 in this chapter and a `#` appears to the left of the heading. Click it to copy a deep link straight to that section.
 
+![Hover state of a heading anchor with copied link toast](images/heading-anchor.svg)
+
 ## How it looks
 
 Move your mouse over any of the headings below. On touch devices the anchor stays visible at low contrast.

--- a/help/chapters/04-whats-new/05-find-on-page.md
+++ b/help/chapters/04-whats-new/05-find-on-page.md
@@ -2,6 +2,8 @@
 
 The search box pulls double duty: typing two or more characters highlights matches **on this page** inline (like browser find) and lists hits in **other chapters** below.
 
+![Find popup with counter and prev/next nav](images/find-on-page.svg)
+
 ## Try it now
 
 1. Press `Ctrl+K` or `Cmd+K` to focus search

--- a/help/chapters/04-whats-new/06-edit-on-github.md
+++ b/help/chapters/04-whats-new/06-edit-on-github.md
@@ -2,6 +2,8 @@
 
 Every chapter can show a muted "Edit this page on GitHub" link at the bottom. Scroll down — there's one on this page right now (above the prev/next nav).
 
+![Edit link preview](images/edit-on-github.svg)
+
 ## Setup
 
 Add a single key to `chapters.json`:

--- a/help/chapters/images/edit-on-github.svg
+++ b/help/chapters/images/edit-on-github.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 120" width="480" height="120" role="img" aria-label="Edit on GitHub link mockup">
+  <rect width="480" height="120" rx="12" fill="#fff8f1"/>
+  <rect x="0.5" y="0.5" width="479" height="119" rx="12" fill="none" stroke="#e8791d" stroke-opacity="0.25"/>
+
+  <rect x="32" y="20" width="416" height="6" rx="2" fill="#1f1407" opacity="0.3"/>
+  <rect x="32" y="34" width="380" height="6" rx="2" fill="#1f1407" opacity="0.3"/>
+  <rect x="32" y="48" width="280" height="6" rx="2" fill="#1f1407" opacity="0.3"/>
+
+  <line x1="32" y1="72" x2="448" y2="72" stroke="#e8791d" stroke-opacity="0.2"/>
+
+  <g transform="translate(32 84)">
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#a08572" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M12 20h9"/>
+      <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z"/>
+    </svg>
+  </g>
+  <text x="56" y="97" font-family="-apple-system, system-ui, sans-serif" font-size="13" fill="#a08572">Edit this page on GitHub</text>
+</svg>

--- a/help/chapters/images/find-on-page.svg
+++ b/help/chapters/images/find-on-page.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 220" width="480" height="220" role="img" aria-label="Find on Page popup mockup">
+  <rect width="480" height="220" rx="12" fill="#fff8f1"/>
+  <rect x="0.5" y="0.5" width="479" height="219" rx="12" fill="none" stroke="#e8791d" stroke-opacity="0.25"/>
+
+  <rect x="80" y="20" width="320" height="36" rx="18" fill="#ffffff" stroke="#e8791d" stroke-opacity="0.3"/>
+  <text x="100" y="42" font-family="-apple-system, system-ui, sans-serif" font-size="13" fill="#1f1407">lazy</text>
+  <rect x="100" y="32" width="2" height="14" fill="#1f1407"/>
+  <text x="380" y="42" font-family="-apple-system, system-ui, sans-serif" font-size="11" fill="#a08572">⌘K</text>
+
+  <rect x="80" y="68" width="320" height="138" rx="10" fill="#ffffff" stroke="#e8791d" stroke-opacity="0.18"/>
+
+  <rect x="80" y="68" width="320" height="34" rx="10" fill="#fef0e1"/>
+  <text x="96" y="90" font-family="-apple-system, system-ui, sans-serif" font-size="12" font-weight="600" fill="#b85a13">2 of 5 on this page</text>
+  <rect x="340" y="76" width="22" height="22" rx="5" fill="#ffffff" stroke="#e8791d" stroke-opacity="0.45"/>
+  <polyline points="346,90 351,84 356,90" fill="none" stroke="#b85a13" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="366" y="76" width="22" height="22" rx="5" fill="#e8791d"/>
+  <polyline points="372,84 377,90 382,84" fill="none" stroke="#fff" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <text x="96" y="124" font-family="-apple-system, system-ui, sans-serif" font-size="10" font-weight="600" fill="#a08572" letter-spacing="0.5">OTHER CHAPTERS</text>
+
+  <text x="96" y="146" font-family="-apple-system, system-ui, sans-serif" font-size="12" font-weight="600" fill="#1f1407">Diagrams (Mermaid)</text>
+  <text x="96" y="162" font-family="-apple-system, system-ui, sans-serif" font-size="11" fill="#6b5949">…the library is </text>
+  <rect x="160" y="151" width="28" height="13" rx="2" fill="#ffec80"/>
+  <text x="163" y="162" font-family="-apple-system, system-ui, sans-serif" font-size="11" font-weight="500" fill="#1f1407">lazy</text>
+  <text x="189" y="162" font-family="-apple-system, system-ui, sans-serif" font-size="11" fill="#6b5949">-loaded from a CDN…</text>
+
+  <text x="96" y="184" font-family="-apple-system, system-ui, sans-serif" font-size="12" font-weight="600" fill="#1f1407">Charts (Chart.js)</text>
+  <text x="96" y="200" font-family="-apple-system, system-ui, sans-serif" font-size="11" fill="#6b5949">…loaded from CDN on demand. </text>
+  <rect x="247" y="189" width="28" height="13" rx="2" fill="#ffec80"/>
+  <text x="250" y="200" font-family="-apple-system, system-ui, sans-serif" font-size="11" font-weight="500" fill="#1f1407">Lazy</text>
+  <text x="276" y="200" font-family="-apple-system, system-ui, sans-serif" font-size="11" fill="#6b5949"> only when needed.</text>
+</svg>

--- a/help/chapters/images/heading-anchor.svg
+++ b/help/chapters/images/heading-anchor.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 160" width="480" height="160" role="img" aria-label="Heading anchor hover preview">
+  <rect width="480" height="160" rx="12" fill="#fff8f1"/>
+  <rect x="0.5" y="0.5" width="479" height="159" rx="12" fill="none" stroke="#e8791d" stroke-opacity="0.25"/>
+
+  <text x="44" y="50" font-family="-apple-system, system-ui, sans-serif" font-size="13" fill="#a08572">#</text>
+  <text x="62" y="50" font-family="-apple-system, system-ui, sans-serif" font-size="22" font-weight="600" fill="#1f1407">Deep Links</text>
+
+  <circle cx="118" cy="44" r="14" fill="none" stroke="#e8791d" stroke-width="1.5" stroke-dasharray="3,3"/>
+  <path d="M118 70 L118 84" stroke="#e8791d" stroke-width="1.5" stroke-dasharray="3,3"/>
+
+  <rect x="44" y="92" width="392" height="46" rx="8" fill="#ffffff" stroke="#e8791d" stroke-opacity="0.3"/>
+  <text x="58" y="116" font-family="-apple-system, ui-monospace, monospace" font-size="11" fill="#1f1407">https://yoursite.com/help/#anchors--deep-links</text>
+  <text x="58" y="132" font-family="-apple-system, system-ui, sans-serif" font-size="10" fill="#22c55e">✓ Link copied</text>
+</svg>

--- a/help/chapters/images/sidebar-mock-dark.svg
+++ b/help/chapters/images/sidebar-mock-dark.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 300" width="480" height="300" role="img" aria-label="Help Book sidebar mockup (dark)">
+  <rect width="480" height="300" rx="12" fill="#1a1410"/>
+  <rect x="0.5" y="0.5" width="479" height="299" rx="12" fill="none" stroke="#e8791d" stroke-opacity="0.4"/>
+
+  <rect x="14" y="14" width="170" height="272" rx="10" fill="#231a13" stroke="#e8791d" stroke-opacity="0.3"/>
+  <circle cx="36" cy="36" r="8" fill="#e8791d"/>
+  <text x="50" y="40" font-family="-apple-system, system-ui, sans-serif" font-size="13" font-weight="600" fill="#f5ead8">Help Book</text>
+
+  <rect x="26" y="64" width="146" height="22" rx="6" fill="#3a2614"/>
+  <text x="36" y="79" font-family="-apple-system, system-ui, sans-serif" font-size="11" fill="#e8791d" font-weight="600">Welcome</text>
+
+  <text x="36" y="106" font-family="-apple-system, system-ui, sans-serif" font-size="11" fill="#7a6856">What's New</text>
+  <text x="50" y="124" font-family="-apple-system, system-ui, sans-serif" font-size="11" fill="#d4c5ad">Images</text>
+  <text x="50" y="142" font-family="-apple-system, system-ui, sans-serif" font-size="11" fill="#d4c5ad">Diagrams</text>
+  <text x="50" y="160" font-family="-apple-system, system-ui, sans-serif" font-size="11" fill="#d4c5ad">Charts</text>
+  <text x="50" y="178" font-family="-apple-system, system-ui, sans-serif" font-size="11" fill="#d4c5ad">Heading Anchors</text>
+  <text x="50" y="196" font-family="-apple-system, system-ui, sans-serif" font-size="11" fill="#d4c5ad">Find on Page</text>
+  <text x="50" y="214" font-family="-apple-system, system-ui, sans-serif" font-size="11" fill="#d4c5ad">Edit on GitHub</text>
+
+  <text x="36" y="238" font-family="-apple-system, system-ui, sans-serif" font-size="11" fill="#7a6856">Configuration</text>
+
+  <rect x="200" y="14" width="266" height="32" rx="8" fill="#231a13" stroke="#e8791d" stroke-opacity="0.3"/>
+  <text x="214" y="34" font-family="-apple-system, system-ui, sans-serif" font-size="11" fill="#7a6856">Search docs… ⌘K</text>
+
+  <rect x="200" y="58" width="266" height="14" rx="3" fill="#f5ead8" opacity="0.95"/>
+  <rect x="200" y="80" width="220" height="8" rx="2" fill="#d4c5ad" opacity="0.6"/>
+  <rect x="200" y="94" width="240" height="8" rx="2" fill="#d4c5ad" opacity="0.6"/>
+  <rect x="200" y="108" width="180" height="8" rx="2" fill="#d4c5ad" opacity="0.6"/>
+
+  <rect x="200" y="132" width="266" height="80" rx="8" fill="#3a2614" stroke="#e8791d" stroke-opacity="0.4"/>
+  <rect x="212" y="146" width="20" height="40" fill="#e8791d"/>
+  <rect x="238" y="156" width="20" height="30" fill="#e8791d" opacity="0.75"/>
+  <rect x="264" y="138" width="20" height="48" fill="#e8791d" opacity="0.9"/>
+  <rect x="290" y="166" width="20" height="20" fill="#e8791d" opacity="0.6"/>
+  <rect x="316" y="150" width="20" height="36" fill="#e8791d" opacity="0.85"/>
+  <text x="354" y="170" font-family="-apple-system, system-ui, sans-serif" font-size="10" fill="#f5b97a">Chart.js</text>
+
+  <rect x="200" y="224" width="266" height="62" rx="8" fill="#231a13" stroke="#e8791d" stroke-opacity="0.3"/>
+  <text x="214" y="244" font-family="-apple-system, system-ui, sans-serif" font-size="11" fill="#d4c5ad">The quick brown fox renders Markdown.</text>
+  <text x="214" y="262" font-family="-apple-system, system-ui, sans-serif" font-size="11" fill="#d4c5ad">Drop in chapters, ship docs.</text>
+  <text x="214" y="278" font-family="-apple-system, system-ui, sans-serif" font-size="10" fill="#7a6856">— Edit this page on GitHub</text>
+</svg>

--- a/help/chapters/images/sidebar-mock.svg
+++ b/help/chapters/images/sidebar-mock.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 300" width="480" height="300" role="img" aria-label="Help Book sidebar mockup">
+  <rect width="480" height="300" rx="12" fill="#fff8f1"/>
+  <rect x="0.5" y="0.5" width="479" height="299" rx="12" fill="none" stroke="#e8791d" stroke-opacity="0.25"/>
+
+  <rect x="14" y="14" width="170" height="272" rx="10" fill="#ffffff" stroke="#e8791d" stroke-opacity="0.18"/>
+  <circle cx="36" cy="36" r="8" fill="#e8791d"/>
+  <text x="50" y="40" font-family="-apple-system, system-ui, sans-serif" font-size="13" font-weight="600" fill="#1f1407">Help Book</text>
+
+  <rect x="26" y="64" width="146" height="22" rx="6" fill="#fef0e1"/>
+  <text x="36" y="79" font-family="-apple-system, system-ui, sans-serif" font-size="11" fill="#b85a13" font-weight="600">Welcome</text>
+
+  <text x="36" y="106" font-family="-apple-system, system-ui, sans-serif" font-size="11" fill="#a08572">What's New</text>
+  <text x="50" y="124" font-family="-apple-system, system-ui, sans-serif" font-size="11" fill="#1f1407">Images</text>
+  <text x="50" y="142" font-family="-apple-system, system-ui, sans-serif" font-size="11" fill="#1f1407">Diagrams</text>
+  <text x="50" y="160" font-family="-apple-system, system-ui, sans-serif" font-size="11" fill="#1f1407">Charts</text>
+  <text x="50" y="178" font-family="-apple-system, system-ui, sans-serif" font-size="11" fill="#1f1407">Heading Anchors</text>
+  <text x="50" y="196" font-family="-apple-system, system-ui, sans-serif" font-size="11" fill="#1f1407">Find on Page</text>
+  <text x="50" y="214" font-family="-apple-system, system-ui, sans-serif" font-size="11" fill="#1f1407">Edit on GitHub</text>
+
+  <text x="36" y="238" font-family="-apple-system, system-ui, sans-serif" font-size="11" fill="#a08572">Configuration</text>
+
+  <rect x="200" y="14" width="266" height="32" rx="8" fill="#ffffff" stroke="#e8791d" stroke-opacity="0.18"/>
+  <text x="214" y="34" font-family="-apple-system, system-ui, sans-serif" font-size="11" fill="#a08572">Search docs… ⌘K</text>
+
+  <rect x="200" y="58" width="266" height="14" rx="3" fill="#1f1407" opacity="0.85"/>
+  <rect x="200" y="80" width="220" height="8" rx="2" fill="#1f1407" opacity="0.35"/>
+  <rect x="200" y="94" width="240" height="8" rx="2" fill="#1f1407" opacity="0.35"/>
+  <rect x="200" y="108" width="180" height="8" rx="2" fill="#1f1407" opacity="0.35"/>
+
+  <rect x="200" y="132" width="266" height="80" rx="8" fill="#fef0e1" stroke="#e8791d" stroke-opacity="0.25"/>
+  <rect x="212" y="146" width="20" height="40" fill="#e8791d"/>
+  <rect x="238" y="156" width="20" height="30" fill="#e8791d" opacity="0.75"/>
+  <rect x="264" y="138" width="20" height="48" fill="#e8791d" opacity="0.9"/>
+  <rect x="290" y="166" width="20" height="20" fill="#e8791d" opacity="0.6"/>
+  <rect x="316" y="150" width="20" height="36" fill="#e8791d" opacity="0.85"/>
+  <text x="354" y="170" font-family="-apple-system, system-ui, sans-serif" font-size="10" fill="#b85a13">Chart.js</text>
+
+  <rect x="200" y="224" width="266" height="62" rx="8" fill="#ffffff" stroke="#e8791d" stroke-opacity="0.18"/>
+  <text x="214" y="244" font-family="-apple-system, system-ui, sans-serif" font-size="11" fill="#1f1407">The quick brown fox renders Markdown.</text>
+  <text x="214" y="262" font-family="-apple-system, system-ui, sans-serif" font-size="11" fill="#1f1407">Drop in chapters, ship docs.</text>
+  <text x="214" y="278" font-family="-apple-system, system-ui, sans-serif" font-size="10" fill="#a08572">— Edit this page on GitHub</text>
+</svg>


### PR DESCRIPTION
Adds 5 inline SVG mockups under `help/chapters/images/` and references them from the relevant feature chapters. All hand-drawn, no external assets.

- sidebar-mock.svg + sidebar-mock-dark.svg → Welcome + Images
- find-on-page.svg → Find on Page
- heading-anchor.svg → Heading Anchors
- edit-on-github.svg → Edit on GitHub