### PR TITLE
release: v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.0] - 2026-05-13
+
+A six-feature release. Most of the work is rendering: diagrams, charts, in-page find, heading anchors, edit-on-GitHub, plus a polish pass on search.
+
 ### Added
 - Configurable "Edit this page on GitHub" link via `editUrl` in `chapters.json`
 - Heading anchor links: hover H2/H3 to reveal a # icon that copies the section URL.
@@ -19,8 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CSP: `script-src` and `connect-src` now include `https://cdn.jsdelivr.net`; `worker-src 'self' blob:` added for mermaid's optional layout workers. Production deployments serving an HTTP CSP header must mirror these.
 - Search results now show a context snippet around the matched term, with the match highlighted.
 
+### Fixed
+- `<img>` paths in chapter markdown are now resolved relative to the chapter's own directory (PR #40 documented this, but `help.js` never wired it up — relative paths 404'd against the SPA root).
+- DOMPurify's URI allowlist accepts bare relative paths like `images/foo.jpg`; previously only `./` and `../`-prefixed paths survived, so the sanitizer silently stripped `src` from any plain-relative image.
+
 ### Documentation
 - Documented image-embedding convention (Markdown syntax, suggested folder layout, sanitizer behavior).
+- Demo chapters rewritten as a feature showcase: every new feature has its own chapter under **What's New**, with the Images chapter as the single place where images and sizing are demonstrated.
 
 ## [2.4.0] - 2026-04-20
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Copy the `help/` folder into your project, edit `chapters.json`, write markdown 
 - Syntax highlighting (highlight.js) with copy-to-clipboard
 - Mermaid diagram support — ```` ```mermaid ```` code blocks render as SVG (lazy-loaded from CDN, theme-aware)
 - Chart.js support: ```` ```chart ```` code blocks with JSON config render as interactive charts (lazy-loaded from CDN, only when a chart appears on the page)
+- Find-on-page: live highlights as you type, `Enter` / `Shift+Enter` to cycle, cross-chapter results below
+- Heading anchors: hover an H2/H3 to reveal a `#` that copies a deep link to that section
+- Optional "Edit this page on GitHub" link per chapter via `editUrl` in `chapters.json`
+- Images via standard Markdown — paths resolve relative to the chapter file, raw `<img width="…">` allowed for sizing
 - Previous / next chapter navigation
 - Mobile responsive with safe-area insets (iPhone notch aware)
 - Accessible: skip-link, ARIA combobox search, keyboard navigation, `prefers-reduced-motion`
@@ -66,7 +70,7 @@ After the first install, every `help/` folder comes with its own updater:
 
 ```bash
 bash help/update          # → latest release
-bash help/update v2.4.0   # → pin a specific version
+bash help/update v2.5.0   # → pin a specific version
 ```
 
 The wrapper resolves the target relative to itself, so it works regardless of the directory you run it from. Your `chapters.json` and everything under `chapters/` is **never touched** — only the bundled code files are replaced.
@@ -82,7 +86,7 @@ cp help/.help-book-backup/update help/ 2>/dev/null
 
 ```bash
 # Pin a specific version
-curl -fsSL https://raw.githubusercontent.com/leminkozey/help-book/main/scripts/install.sh | bash -s v2.4.0
+curl -fsSL https://raw.githubusercontent.com/leminkozey/help-book/main/scripts/install.sh | bash -s v2.5.0
 
 # Custom target directory (default: ./help)
 HELP_BOOK_DIR=public/docs curl -fsSL https://raw.githubusercontent.com/leminkozey/help-book/main/scripts/install.sh | bash

--- a/help/chapters.json
+++ b/help/chapters.json
@@ -1,6 +1,6 @@
 {
   "title": "Help Book Demo",
-  "version": "v2.5.0-dev",
+  "version": "v2.5.0",
   "accent": "#e8791d",
   "editUrl": "https://github.com/leminkozey/help-book/edit/main/help/{file}",
   "chapters": [


### PR DESCRIPTION
Promote Unreleased changes to v2.5.0. Tag wird nach Merge gepusht — Release-Action erstellt automatisch GitHub Release + Changelog + ZIP-Asset.